### PR TITLE
modified creation-date tag format

### DIFF
--- a/common/tasks/rosa/hosted-cp/rosa-hcp-provision/rosa-hcp-provision.yaml
+++ b/common/tasks/rosa/hosted-cp/rosa-hcp-provision/rosa-hcp-provision.yaml
@@ -164,7 +164,7 @@ spec:
                 --subnet-ids="$SUBNET_IDS" \
                 --billing-account "$BILLING_ACCOUNT_ID" \
                 --replicas $(params.replicas) \
-                --tags konflux-ci:true,creation-date:$(date -u +"%Y-%m-%dT%H:%M:%SZ"),cluster-type:rosa-hcp \
+                --tags konflux-ci:true,creation-date:$(date -u +"%Y-%m-%d"),cluster-type:rosa-hcp \
                 --hosted-cp -y
 
             printf "INFO: Track the progress of the cluster creation...\n" 


### PR DESCRIPTION
Fixed the tag issue `invalid tag format for tag '[creation-date 2024-05-30T08 04 24Z]'. Expected tag format: 'key:value'`