### PR TITLE
feat: deploy-konflux and aws-kind: store logs

### DIFF
--- a/tasks/konflux-ci/deploy/0.2/MIGRATION.md
+++ b/tasks/konflux-ci/deploy/0.2/MIGRATION.md
@@ -1,0 +1,6 @@
+# Migration from 0.1 to 0.2
+The parameter `oci-ref` was added to the task.
+The parameter `oci-credentials` was added to the task.
+
+## Action from users
+Add the `oci-ref` and `oci-credentials` parameters to the `deploy-konflux-ci` task.

--- a/tasks/konflux-ci/deploy/0.2/Readme.md
+++ b/tasks/konflux-ci/deploy/0.2/Readme.md
@@ -1,0 +1,93 @@
+# 🚀 Tekton Task: `deploy-konflux-ci`
+
+Version: 0.2
+
+This task automates the deployment of [Konflux CI](https://github.com/konflux-ci/konflux-ci) into a Kubernetes or OpenShift environment.
+It is tailored for use within OpenShift Pipelines (Tekton) and supports full setup, including dependencies, policies, and test resources.
+
+---
+
+## 📘 Overview
+
+The task performs the following operations:
+
+1. Clones the Konflux CI Git repository.
+1. Checks out the specified branch.
+1. Retrieves a `kubeconfig` from a Kubernetes Secret to access a target cluster.
+1. Optionally modifies kustomization files if specific component overrides are provided.
+1. Executes the deployment sequence using `deploy-deps.sh`, `wait-for-all.sh`, and `deploy-konflux.sh`.
+1. Optionally deploys test resources using `deploy-test-resources.sh`.
+1. Stores logs in specified OCI artifact
+
+---
+
+## 🔧 Parameters
+
+| Name                      | Description                                                                                                                               | Default                                        | Required |
+| :------------------------ | :---------------------------------------------------------------------------------------------------------------------------------------- | :--------------------------------------------- | :------- |
+| `cluster-access-secret`   | Name of the Secret containing a base64-encoded `kubeconfig`.                                                                              | —                                              | ✅       |
+| `repo-url`                | Git repository URL of the Konflux CI deployment scripts.                                                                                  | `https://github.com/konflux-ci/konflux-ci.git` | ❌       |
+| `repo-branch`             | Git branch to check out.                                                                                                                  | `main`                                         | ❌       |
+| `create-test-resources`   | Flag to determine whether test resources should be deployed.                                                                              | `true`                                         | ❌       |
+| `component-name`          | The GitHub repository name of the Konflux CI component to customize (e.g., `build-service`). Used for image or K8s manifest overrides. | `''`                                           | ❌       |
+| `component-image-repository` | Overrides the container image repository for the `component-name` (e.g., `quay.io/my-org/my-custom-image`).                                | `''`                                           | ❌       |
+| `component-image-tag`     | Overrides the container image tag for the `component-name` (e.g., `latest`, `my-feature-branch`).                                         | `''`                                           | ❌       |
+| `component-pr-owner`      | GitHub owner (user/org) of the fork/PR providing custom Kubernetes manifests for the `component-name`.                                    | `''`                                           | ❌       |
+| `component-pr-sha`        | Commit SHA of the PR (from `component-pr-owner`) supplying custom Kubernetes manifests for the `component-name`.                            | `''`                                           | ❌       |
+| `component-pr-source-branch`        | GitHub source branch of the pull request.     | `''`    | ❌       |
+| `oci-ref`                     | Full OCI artifact reference used for storing logs from the Task's Steps    | -        | ✅       |
+| `oci-credentials`             | The secret name containing credentials for container registry where the artifacts will be stored.  | -    | ✅       |
+
+---
+
+### ✨ Advanced: Component Overrides
+
+The parameters starting with `component-` allow for targeted customization of a specific Konflux CI component during deployment.
+
+* To use these overrides, you **must** specify the `component-name`.
+* **Image Override**: If you provide `component-name` along with `component-image-repository` and/or `component-image-tag`, the task will attempt to modify the deployment to use the specified container image for that component.
+* **Kubernetes Manifest Override**: If you provide `component-name` along with `component-pr-owner` and `component-pr-sha`, the task will attempt to fetch the component's Kubernetes manifests from the specified GitHub pull request, allowing you to test changes from a specific fork and commit.
+
+These parameters are particularly useful for development and testing of individual Konflux CI components.
+
+---
+
+## 📁 Volumes
+
+| Name      | Type       | Description                                            |
+| :-------- | :--------- | :----------------------------------------------------- |
+| `workdir` | `emptyDir` | Used as working directory for cloning and running scripts. |
+
+---
+
+## 🧱 Steps
+
+1. **`clone-konflux-ci`**
+    Clones the Konflux CI repository and checks out the specified branch.
+1. **`update-kustomization`** *(conditional)*
+    If `component-name` is provided, this step modifies the kustomization files to use custom images or manifest sources for the specified component.
+1. **`get-kubeconfig`**
+    Fetches and decodes the kubeconfig from the provided secret and sets up the Kubernetes context.
+1. **`deploy`**
+    Runs main deployment scripts (`deploy-deps.sh`, `wait-for-all.sh`, `deploy-konflux.sh`).
+1. **`create-test-resources`** *(conditional)*
+    Deploys additional test resources if `create-test-resources` is set to `true`.
+1. **`secure-push-oci`**
+    Stores logs from deploying konflux in OCI artifact
+1. **`fail-if-any-step-failed`**
+    If any of the previous steps fail, this step fails
+---
+
+## 🔐 Required Secret Format
+
+The task expects a Kubernetes Secret with kubeconfig that looks like:
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: <your-secret-name>
+  namespace: <your-namespace>
+type: Opaque
+data:
+  kubeconfig: <base64-encoded-kubeconfig>

--- a/tasks/konflux-ci/deploy/0.2/deploy-konflux-ci.yaml
+++ b/tasks/konflux-ci/deploy/0.2/deploy-konflux-ci.yaml
@@ -1,0 +1,253 @@
+---
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: deploy-konflux-ci
+  labels:
+    konflux-ci/kind: "true"
+    app.kubernetes.io/version: "0.2"
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.44.x"
+    tekton.dev/tags: konflux
+spec:
+  description: |
+    This task performs a full Konflux CI deployment. It clones the specified Git repository,
+    checks out the desired branch, and runs deployment scripts using a kubeconfig retrieved from
+    a Kubernetes secret. It is intended for use in OpenShift Pipelines or other Tekton environments.
+
+  params:
+    - name: cluster-access-secret
+      description: Name of the Kubernetes Secret that contains the kubeconfig (base64 encoded) used to access the target cluster.
+    - name: repo-url
+      description: URL of the Git repository containing the Konflux CI deployment scripts.
+      default: https://github.com/konflux-ci/konflux-ci.git
+    - name: repo-branch
+      description: Git branch to check out when cloning the repository.
+      default: main
+    - name: create-test-resources
+      description: 'Indicates if a set of test resources should be installed'
+      default: 'true'
+    - name: component-name
+      description: |
+        The GitHub repository name of the Konflux CI component to customize (e.g., `build-service`, `release-service`).
+        Used for applying image or Kubernetes manifest overrides.
+      default: ''
+    - name: component-image-repository
+      description: |
+        Overrides the container image repository for the `component-name` (e.g., `quay.io/my-org/my-custom-image`).
+      default: ''
+    - name: component-image-tag
+      description: |
+        Overrides the container image tag for the `component-name` (e.g., `latest`, `my-feature-branch`).
+      default: ''
+    - name: component-pr-owner
+      description: |
+        GitHub owner (user|org) of the fork/PR providing custom Kubernetes manifests for the `component-name`.
+      default: ''
+    - name: component-pr-sha
+      description: |
+        Commit SHA of the PR (from `component-pr-owner`) supplying custom Kubernetes manifests for the `component-name`.
+      default: ''
+    - name: component-pr-source-branch
+      description: |
+        GitHub source branch of the pull request.
+      default: ''
+    - name: oci-ref
+      type: string
+      description: Full OCI artifact reference in a format "quay.io/org/repo:tag. It's used for storing logs from the Task's Steps
+    - name: oci-credentials
+      type: string
+      description: |
+        The secret name containing credentials for container registry where the artifacts will be stored.
+      default: "konflux-test-infra"
+
+  volumes:
+    - name: credentials
+      secret:
+        secretName: $(params.cluster-access-secret)
+    - name: workdir
+      emptyDir: {}
+    - name: logs
+      emptyDir: {}
+    - name: konflux-test-infra-volume
+      secret:
+        secretName: $(params.oci-credentials)
+
+  stepTemplate:
+    env:
+      - name: KUBECONFIG
+        value: '/credentials/kubeconfig'
+      - name: LOG_FILENAME
+        value: '/var/log-dir/deploy-konflux-ci.log'
+    volumeMounts:
+      - name: credentials
+        mountPath: /credentials
+      - name: workdir
+        mountPath: /var/workdir
+      - name: logs
+        mountPath: /var/log-dir/
+
+  steps:
+    - name: clone-konflux-ci
+      image: quay.io/openshift-pipeline/pipelines-git-init-rhel9@sha256:7eee14366c516d92cf7480c9bc256cf0e544bf06da5d46ffb5e8bfe3e448326c
+      onError: continue
+      workingDir: /var/workdir
+      securityContext:
+        runAsUser: 0
+      args:
+        - -url=$(params.repo-url)
+        - -revision=$(params.repo-branch)
+        - -path=.
+    - name: solve-pr-pairing
+      image: quay.io/konflux-ci/tekton-integration-catalog/utils:latest
+      onError: continue
+      workingDir: /var/workdir
+      when:
+        - input: "$(params.component-name)"
+          operator: notin
+          values: [ "" ]
+      script: |
+        #!/bin/bash
+        set -euo pipefail
+
+        {
+          PR_SOURCE_BRANCH=$(params.component-pr-source-branch)
+          COMPONENT_NAME="$(params.component-name)"
+          PR_AUTHOR=$(params.component-pr-owner)
+
+          if [ $COMPONENT_NAME == "release-service-catalog" ]; then
+            PR_TO_PAIR=$(curl -s https://api.github.com/repos/konflux-ci/release-service/pulls\?per_page\=100 | jq -r ".[] | select(.user.login == \"$PR_AUTHOR\" and .head.ref == \"$PR_SOURCE_BRANCH\")")
+
+            if [ -n "$PR_TO_PAIR" ]; then
+              PAIRED_PR_SHA=$(jq -r '.head.sha' <<< $PR_TO_PAIR)
+
+              mkdir -p /var/workdir/
+              echo "COMPONENT_NAME=release-service" >> /var/workdir/.env
+              echo "IMAGE_REPO=quay.io/redhat-user-workloads/rhtap-release-2-tenant/release-service/release-service" >> /var/workdir/.env
+              echo "IMAGE_TAG=on-pr-$PAIRED_PR_SHA" >> /var/workdir/.env
+              echo "PR_OWNER=$PR_AUTHOR" >> /var/workdir/.env
+              echo "PR_SHA=$PAIRED_PR_SHA" >> /var/workdir/.env
+            fi
+          fi
+        } 2>&1 | tee -a $LOG_FILENAME
+
+    - name: update-kustomization
+      image: quay.io/konflux-ci/tekton-integration-catalog/utils:latest
+      onError: continue
+      workingDir: /var/workdir
+      when:
+        - input: "$(params.component-name)"
+          operator: notin
+          values: [ "" ]
+      script: |
+        #!/bin/bash
+        set -euo pipefail
+
+        {
+          if [ -f /var/workdir/.env ]; then
+            echo "[INFO] Loading env vars from /var/workdir/.env: $(cat /var/workdir/.env)"
+            source /var/workdir/.env
+          else
+            echo "[INFO] Loading env vars from parameters"
+
+            COMPONENT_NAME="$(params.component-name)"
+            IMAGE_REPO="$(params.component-image-repository)"
+            IMAGE_TAG="$(params.component-image-tag)"
+            PR_OWNER="$(params.component-pr-owner)"
+            PR_SHA="$(params.component-pr-sha)"
+          fi
+
+          # Repo names do not match the ones of the component. Try to find the right kustomization.yaml based on the component name.
+          KUSTOMIZATION_PATH=$(find konflux-ci/ -type f -name "kustomization.yaml" -path "*${COMPONENT_NAME%-service}*/core/*" | head -n 1)
+
+          # Check if the file exists
+          if [[ ! -f "${KUSTOMIZATION_PATH}" ]]; then
+            echo "[WARNING] No substitutions will be applied as the kustomization file for $(params.component-name) has not been found."
+            exit 0
+          fi
+
+          # Apply substitutions
+          if [[ -n "$IMAGE_REPO" ]]; then
+            echo "[INFO] Updating image repository to $IMAGE_REPO"
+            yq -i e "(.images.[] | select(.name==\"quay.io/konflux-ci/${COMPONENT_NAME}\")) |= .newName=\"${IMAGE_REPO}\"" "$KUSTOMIZATION_PATH"
+          fi
+
+          if [[ -n "$IMAGE_TAG" ]]; then
+            echo "[INFO] Updating image tag to $IMAGE_TAG"
+            yq -i e "(.images.[] | select(.name==\"quay.io/konflux-ci/${COMPONENT_NAME}\")) |= .newTag=\"${IMAGE_TAG}\"" "$KUSTOMIZATION_PATH"
+          fi
+
+          if [[ -n "$PR_OWNER" && -n "$PR_SHA" ]]; then
+            echo "[INFO] Updating GitHub reference to $PR_OWNER@$PR_SHA"
+            yq -i e "(.resources[] | select(. ==\"*github.com/konflux-ci/${COMPONENT_NAME}/config/default*\")) |= \"https://github.com/${PR_OWNER}/${COMPONENT_NAME}/config/default?ref=${PR_SHA}\"" "$KUSTOMIZATION_PATH"
+            yq -i e "(.resources[] | select(. ==\"*github.com/konflux-ci/${COMPONENT_NAME}/config/snapshotgc*\")) |= \"https://github.com/${PR_OWNER}/${COMPONENT_NAME}/config/snapshotgc?ref=${PR_SHA}\"" "$KUSTOMIZATION_PATH"
+          fi
+        } 2>&1 | tee -a $LOG_FILENAME
+
+    - name: deploy
+      image: quay.io/konflux-ci/tekton-integration-catalog/utils:latest
+      onError: continue
+      workingDir: /var/workdir
+      script: |
+        #!/bin/bash
+        set -euo pipefail
+        
+        {
+          kubectl cluster-info
+
+          echo "[INFO] Installing Konflux CI dependencies"
+          ./deploy-deps.sh
+          ./wait-for-all.sh
+
+          echo "[INFO] Installing Konflux CI..."
+          ./deploy-konflux.sh
+
+          kubectl get po -A
+        } 2>&1 | tee -a $LOG_FILENAME
+    - name: create-test-resources
+      image: quay.io/konflux-ci/tekton-integration-catalog/utils:latest
+      onError: continue
+      workingDir: /var/workdir
+      when:
+        - input: "$(params.create-test-resources)"
+          operator: in
+          values: ["true"]
+      script: |
+        #!/bin/bash
+        set -euo pipefail
+
+        {
+        echo "[INFO] Applying Kyverno to reduce resources for testing"
+        kubectl apply -f ./dependencies/kyverno/policy/e2e-reduce-resources.yaml
+
+        echo "[INFO] Creating Test Resources..."
+        ./deploy-test-resources.sh
+        } 2>&1 | tee -a $LOG_FILENAME
+
+    - name: secure-push-oci
+      ref:
+        resolver: git
+        params:
+          - name: url
+            value: https://github.com/konflux-ci/tekton-integration-catalog.git
+          - name: revision
+            value: main
+          - name: pathInRepo
+            value: stepactions/secure-push-oci/0.1/secure-push-oci.yaml
+      params:
+        - name: workdir-path
+          value: /var/log-dir/
+        - name: oci-ref
+          value: $(params.oci-ref)
+        - name: credentials-volume-name
+          value: konflux-test-infra-volume
+    - name: fail-if-any-step-failed
+      ref:
+        resolver: git
+        params:
+          - name: url
+            value: https://github.com/konflux-ci/tekton-integration-catalog.git
+          - name: revision
+            value: main
+          - name: pathInRepo
+            value: stepactions/fail-if-any-step-failed/0.1/fail-if-any-step-failed.yaml

--- a/tasks/mapt-oci/kind-aws-spot/provision/0.2/MIGRATION.md
+++ b/tasks/mapt-oci/kind-aws-spot/provision/0.2/MIGRATION.md
@@ -1,0 +1,6 @@
+# Migration from 0.1 to 0.2
+The parameter `oci-ref` was added to the task.
+The parameter `oci-credentials` was added to the task.
+
+## Action from users
+Add the `oci-ref` and `oci-credentials` parameters to the `kind-aws-provision` task.

--- a/tasks/mapt-oci/kind-aws-spot/provision/0.2/Readme.md
+++ b/tasks/mapt-oci/kind-aws-spot/provision/0.2/Readme.md
@@ -1,0 +1,158 @@
+
+# 🚀 Tekton Task: `kind-aws-provision`
+
+**Version:** 0.2
+
+Create a Kind (Kubernetes in Docker) cluster on AWS using the [Mapt CLI](https://github.com/redhat-developer/mapt).
+This task is ideal for managing **ephemeral clusters** in Tekton-based CI/CD workflows.
+
+---
+
+## ✅ Requirements
+
+- Tekton Pipelines v0.44.x or newer
+- Valid AWS credentials stored as a Kubernetes Secret
+
+---
+
+## 📘 Overview
+
+This task provisions a single-node Kubernetes cluster on AWS using Mapt. It outputs a `kubeconfig` as a Kubernetes Secret for use in later pipeline steps.
+
+### Supported Features
+
+- Spot instance provisioning for cost savings
+- Nested virtualization support
+- Customizable CPU, memory, and architecture
+- Optional timeout for auto-destroy
+- Owner-referenced Secret creation for lifecycle management
+
+---
+
+## 🔧 Parameters
+
+| Name                          | Description                                                                 | Default     | Required |
+|-------------------------------|-----------------------------------------------------------------------------|-------------|----------|
+| `secret-aws-credentials`      | Kubernetes Secret with AWS credentials (`access-key`, `secret-key`, etc.)  | —           | ✅       |
+| `id`                          | Unique identifier for the Kind cluster environment                         | —           | ✅       |
+| `cluster-access-secret-name` | Optional: name for the output kubeconfig Secret                             | `''`        | ❌       |
+| `ownerKind`                   | Type of resource owning the Secret (`PipelineRun`, `TaskRun`)               | `PipelineRun`| ❌       |
+| `ownerName`                   | Name of the owning resource                                                 | —           | ✅       |
+| `ownerUid`                    | UID of the owning resource                                                  | —           | ✅       |
+| `arch`                        | Instance architecture (`x86_64`, `arm64`)                                   | `x86_64`    | ❌       |
+| `cpus`                        | Number of vCPUs to provision                                                | `16`        | ❌       |
+| `memory`                      | Memory in GiB                                                               | `64`        | ❌       |
+| `nested-virt`                 | Enable nested virtualization                                                | `false`     | ❌       |
+| `spot`                        | Use spot instances                                                          | `true`      | ❌       |
+| `spot-increase-rate`         | % increase on spot price to improve instance allocation                     | `20`        | ❌       |
+| `version`                     | Kubernetes version                                                          | `v1.32`     | ❌       |
+| `tags`                        | AWS resource tags                                                           | `''`        | ❌       |
+| `debug`                       | Enable verbose output (prints credentials; use with caution)               | `false`     | ❌       |
+| `timeout`                     | Auto-destroy timeout (`1h`, `30m`, etc.)                                    | `2h`        | ❌       |
+| `oci-ref`                     | Full OCI artifact reference used for storing logs from the Task's Steps    | -        | ✅       |
+| `oci-credentials`             | The secret name containing credentials for container registry where the artifacts will be stored.  | -    | ✅       |
+
+---
+
+## 📤 Result
+
+| Result                   | Description                                                   |
+|--------------------------|---------------------------------------------------------------|
+| `cluster-access-secret` | Name of the generated Kubernetes Secret containing kubeconfig  |
+
+### Example output Secret
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: <generated-or-specified-name>
+type: Opaque
+data:
+  kubeconfig: <base64-encoded>
+```
+
+---
+
+## 🔐 AWS Credentials Secret Format
+
+Create a Kubernetes Secret like this:
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: aws-my-creds
+type: Opaque
+data:
+  access-key: <base64>
+  secret-key: <base64>
+  region: <base64>
+  bucket: <base64>
+```
+
+---
+
+## 📦 Example: How to Use the Kubeconfig in Another Task
+
+After provisioning the cluster, you can make the generated `kubeconfig` available to all task steps by directly mounting the Secret containing it.
+**Use a `stepTemplate` and a Secret-based volume to simplify kubeconfig access.**
+
+### ✅ Recommended Configuration
+
+```yaml
+volumes:
+  - name: credentials
+    secret:
+      secretName: $(params.cluster-access-secret)
+
+stepTemplate:
+  env:
+    - name: KUBECONFIG
+      value: "/credentials/kubeconfig"
+  volumeMounts:
+    - name: credentials
+      mountPath: /credentials
+```
+
+### 💡 Benefits
+
+- Automatically sets the `KUBECONFIG` environment variable for every step.
+- No need to manually decode or copy the kubeconfig.
+- Compatible with CLI tools like `kubectl`, `helm`, etc.
+
+---
+
+## 🔐 Permissions Note
+
+The **ServiceAccount** (used to run the `Konflux PipelineRun`) must have RBAC permissions to manage Secrets in the namespace where the `cluster-access-secret` will be created. These permissions are required to dynamically create and manage the kubeconfig Secret for testing in Ephemeral Clusters.
+
+```yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: secret-kind-role
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "list", "create"]
+```
+
+Bind this role to your pipeline's ServiceAccount with a `RoleBinding`:
+
+```yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: tekton-secret-manager-binding
+subjects:
+  - kind: ServiceAccount
+    name: <your-service-account>
+    namespace: <namespace>
+roleRef:
+  kind: Role
+  name: tekton-secret-manager
+  apiGroup: rbac.authorization.k8s.io
+```
+
+> **Note:** Without these permissions, the task will fail when attempting to create the kubeconfig Secret.

--- a/tasks/mapt-oci/kind-aws-spot/provision/0.2/kind-aws-provision.yaml
+++ b/tasks/mapt-oci/kind-aws-spot/provision/0.2/kind-aws-provision.yaml
@@ -1,0 +1,250 @@
+---
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: kind-aws-provision
+  labels:
+    app.kubernetes.io/version: "0.2"
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.44.x"
+    tekton.dev/categories: infrastructure
+    tekton.dev/tags: infrastructure, aws, kind
+    tekton.dev/displayName: "Kind Cloud Single Node - Create"
+    tekton.dev/platforms: "linux/amd64, linux/arm64"
+    mapt/version: "v0.9.1"
+spec:
+  description: |
+    Creates a single-node Kubernetes cluster using Kind on AWS, powered by the Mapt CLI.
+    This task is ideal for setting up ephemeral clusters for testing or CI/CD workflows.
+
+    It supports:
+      - Spot instance provisioning and nested virtualization
+      - Custom CPU, memory, and architecture configurations
+      - Automatic cluster cleanup via timeout
+      - Securely exposes the generated kubeconfig as a Kubernetes Secret
+
+  volumes:
+    - name: aws-credentials
+      secret:
+        secretName: $(params.secret-aws-credentials)
+    - name: cluster-info
+      emptyDir: {}
+    - name: logs
+      emptyDir: {}
+    - name: konflux-test-infra-volume
+      secret:
+        secretName: $(params.oci-credentials)
+
+  params:
+    - name: secret-aws-credentials
+      description: |
+        K8S secret holding the aws credentials. Secret should be accessible to this task.
+
+        ---
+        apiVersion: v1
+        kind: Secret
+        metadata:
+          name: aws-${name}
+        type: Opaque
+        data:
+          access-key: ${access_key}
+          secret-key: ${secret_key}
+          region: ${region}
+          bucket: ${bucket}
+    - name: id
+      description: A unique identifier for this Kind environment
+    - name: cluster-access-secret-name
+      type: string
+      default: "''"
+      description: |
+        (Optional) The name to assign to the Kubernetes Secret that will store
+        the kubeconfig for the created cluster. If not specified, a name will be auto-generated.
+    - name: ownerKind
+      type: string
+      default: PipelineRun
+      description: |
+        The type of Tekton resource (e.g., PipelineRun or TaskRun) that should own the kubeconfig Secret.
+        Deleting this owner will also delete the Secret automatically.
+    - name: ownerName
+      type: string
+      description: |
+        The name of the PipelineRun or TaskRun that owns the resources.
+    - name: ownerUid
+      type: string
+      description: |
+        The UID of the PipelineRun or TaskRun that owns the resources. This ensures proper cleanup.
+    - name: arch
+      description: |
+        The architecture of the instance to launch. Choose between `x86_64` or `arm64`.
+      default: 'x86_64'
+    - name: cpus
+      description: |
+        The number of vCPUs to allocate to the virtual machine.
+      default: '16'
+    - name: memory
+      description: |
+        The amount of memory (in GiB) to allocate to the virtual machine.
+      default: '64'
+    - name: nested-virt
+      description: |
+        Enables nested virtualization if set to `true`. Useful for running Kind inside a VM.
+      default: 'false'
+    - name: spot
+      description: |
+        Use spot instances to potentially reduce costs. Set to `true` to enable.
+      default: 'true'
+    - name: spot-increase-rate
+      description: |
+        Adds a percentage to the base spot price to improve chances of getting the instance.
+      default: '20'
+    - name: version
+      description: |
+        The desired Kubernetes version for the Kind cluster. If left blank, the latest stable version will be used.
+      default: 'v1.32'
+    - name: tags
+      description: AWS resource tags
+      default: "''"
+    - name: debug
+      description: |
+        Enables verbose logging and prints sensitive data like credentials.
+        Only use this for debugging in secure environments.
+      default: 'false'
+    - name: timeout
+      description: The Timeout value is a duration conforming to Go ParseDuration format. This will set a serverless destroy operation based on this.
+      default: "2h"
+    - name: oci-ref
+      type: string
+      description: Full OCI artifact reference in a format "quay.io/org/repo:tag. It's used for storing logs from the Task's Steps
+    - name: oci-credentials
+      type: string
+      description: |
+        The secret name containing credentials for container registry where the artifacts will be stored.
+      default: "konflux-test-infra"
+
+  results:
+    - name: cluster-access-secret
+      description: Secret with kubeconfig
+
+  stepTemplate:
+    env:
+      - name: LOG_FILENAME
+        value: '/var/log-dir/kind-aws-provision.log'
+    volumeMounts:
+      - name: logs
+        mountPath: /var/log-dir
+
+  steps:
+    - name: provisioner
+      onError: continue
+      image: quay.io/redhat-developer/mapt:v0.9.1
+      volumeMounts:
+        - name: aws-credentials
+          mountPath: /opt/aws-credentials
+        - name: cluster-info
+          mountPath: /opt/cluster-info
+      script: |
+        #!/bin/sh
+        set -euo pipefail
+        if [[ $(params.debug) == "true" ]]; then set -xeuo pipefail; fi
+
+        export AWS_ACCESS_KEY_ID=$(cat /opt/aws-credentials/access-key)
+        export AWS_SECRET_ACCESS_KEY=$(cat /opt/aws-credentials/secret-key)
+        export AWS_DEFAULT_REGION=$(cat /opt/aws-credentials/region)
+        BUCKET=$(cat /opt/aws-credentials/bucket)
+
+        cmd="mapt aws kind create "
+        cmd+="--project-name kind-$(params.id) "
+        cmd+="--backed-url s3://${BUCKET}/mapt/kind/$(params.id) "
+        cmd+="--conn-details-output /opt/cluster-info "
+        cmd+="--arch $(params.arch) "
+        cmd+="--cpus $(params.cpus) "
+        cmd+="--memory $(params.memory) "
+        if [[ $(params.nested-virt) == "true" ]]; then cmd+="--nested-virt "; fi
+        if [[ $(params.version) != "" ]]; then cmd+="--version $(params.version) "; fi
+        if [[ $(params.spot) == "true" ]]; then
+          cmd+="--spot --spot-increase-rate $(params.spot-increase-rate) "
+        fi
+        if [[ $(params.timeout) != "" ]]; then cmd+="--timeout $(params.timeout) "; fi
+        cmd+="--tags $(params.tags) "
+
+        eval "${cmd}" 2>&1 | tee $LOG_FILENAME
+
+      computeResources:
+        requests:
+          memory: "200Mi"
+          cpu: "100m"
+        limits:
+          memory: "600Mi"
+          cpu: "300m"
+
+    - name: host-info-secret
+      onError: continue
+      image: registry.redhat.io/openshift4/ose-cli:4.13@sha256:e70eb2be867f1236b19f5cbfeb8e0625737ce0ec1369e32a4f9f146aaaf68d49
+      env:
+        - name: NAMESPACE
+          value: $(context.taskRun.namespace)
+        - name: OWNER_KIND
+          value: $(params.ownerKind)
+        - name: OWNER_NAME
+          value: $(params.ownerName)
+        - name: OWNER_UID
+          value: $(params.ownerUid)
+      volumeMounts:
+        - name: cluster-info
+          mountPath: /opt/cluster-info
+      script: |
+        #!/bin/bash
+        set -eo pipefail
+        export SECRETNAME="generateName: mapt-aws-kind-"
+        if [[ $(params.cluster-access-secret-name) != "" ]]; then
+          export SECRETNAME="name: $(params.cluster-access-secret-name)"
+        fi
+        cat <<EOF > cluster-info.yaml
+        apiVersion: v1
+        kind: Secret
+        metadata:
+          $SECRETNAME
+          namespace: $NAMESPACE
+          ownerReferences:
+          - apiVersion: tekton.dev/v1
+            kind: $OWNER_KIND
+            name: $OWNER_NAME
+            uid: $OWNER_UID
+        type: Opaque
+        data:
+          kubeconfig: $(cat /opt/cluster-info/kubeconfig | base64 -w0)
+        EOF
+
+        if [[ $(params.debug) == "true" ]]; then
+          cat /opt/cluster-info/*
+        fi
+
+        NAME=$(oc create -f cluster-info.yaml -o=jsonpath='{.metadata.name}')
+        echo -n "${NAME}" | tee $(results.cluster-access-secret.path)
+    - name: secure-push-oci
+      ref:
+        resolver: git
+        params:
+          - name: url
+            value: https://github.com/konflux-ci/tekton-integration-catalog.git
+          - name: revision
+            value: main
+          - name: pathInRepo
+            value: stepactions/secure-push-oci/0.1/secure-push-oci.yaml
+      params:
+        - name: workdir-path
+          value: /var/log-dir
+        - name: oci-ref
+          value: $(params.oci-ref)
+        - name: credentials-volume-name
+          value: konflux-test-infra-volume
+    - name: fail-if-any-step-failed
+      ref:
+        resolver: git
+        params:
+          - name: url
+            value: https://github.com/konflux-ci/tekton-integration-catalog.git
+          - name: revision
+            value: main
+          - name: pathInRepo
+            value: stepactions/fail-if-any-step-failed/0.1/fail-if-any-step-failed.yaml


### PR DESCRIPTION
https://issues.redhat.com/browse/KFLUXDP-313

* add Steps for scanning logs and pushing the censored content to quay.io as OCI artifact to deploy-konflux-ci and kind-provision Tasks
* bump the versions of those Tasks, because they introduce a breaking version

Tested with [this PR](https://github.com/konflux-ci/release-service-catalog/pull/1014/files) - see the [logs in artifact browser](https://app-artifact-browser.apps.rosa.konflux-qe.zmr9.p3.openshiftapps.com/release-service-catalog/konflux-e2e-tests-catalog-zg5sj/deploy-konflux-ci.log)