### PR TITLE
fix: jenkins-trigger: filename in param detection

### DIFF
--- a/tasks/triggers/jenkins/0.1/trigger-jenkins-job.yaml
+++ b/tasks/triggers/jenkins/0.1/trigger-jenkins-job.yaml
@@ -63,7 +63,7 @@ spec:
             data = {}
             filename = ""
             for params in args:
-                if "@" in params:
+                if "=@" in params:
                     filename += params.split("=")[1][1:]
                 elif "=" in params:
                     key_value = params.split("=")


### PR DESCRIPTION
# Description
Expect the filename to be defined by right after "=@" string when parsing params