### PR TITLE
feat: add internal/upstream labeling

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,6 +23,7 @@ Thank you for your interest in contributing! This project benefits from a collab
    - Add new Tekton Tasks, StepActions, or Pipelines.
    - If updating an existing task, **ensure backward compatibility** or create a new version.
    - Update documentation if needed.
+   - Ensure appropriate upstream labels are added.
 
 4. **Test Your Changes**
    - Validate YAML files to check for syntax errors.

--- a/pipelineruns/conforma-with-waiting/0.1/README.MD
+++ b/pipelineruns/conforma-with-waiting/0.1/README.MD
@@ -74,3 +74,5 @@ spec:
         value: pipelineruns/conforma-with-waiting/0.1/conforma-with-waiting.yaml
     resolver: git
 ```
+
+### Not suitable for upstream communities

--- a/pipelineruns/conforma-with-waiting/0.1/conforma-with-waiting.yaml
+++ b/pipelineruns/conforma-with-waiting/0.1/conforma-with-waiting.yaml
@@ -1,5 +1,9 @@
 apiVersion: tekton.dev/v1
 kind: PipelineRun
+metadata:
+  name: conforma-with-waiting
+  labels:
+    upstream-usable: "false"
 spec:
   pipelineSpec:
     params:

--- a/pipelineruns/deploy-fbc-operator/0.1/deploy-fbc-operator-run.yaml
+++ b/pipelineruns/deploy-fbc-operator/0.1/deploy-fbc-operator-run.yaml
@@ -2,6 +2,8 @@ apiVersion: tekton.dev/v1
 kind: PipelineRun
 metadata:
   name: deploy-fbc-operator-run
+  labels:
+    upstream-usable: "true"
 spec:
   pipelineRef:
     resolver: git

--- a/pipelines/deploy-fbc-operator/0.1/README.MD
+++ b/pipelines/deploy-fbc-operator/0.1/README.MD
@@ -197,3 +197,5 @@ Once your FBC component is built, the `deploy-fbc-operator` pipeline will be tri
 Currently, pipeline failures only block the auto-release of the Snapshot. They do *not* prevent users from manually releasing.
 
 Until [KONFLUX-7345](https://issues.redhat.com/browse/KONFLUX-7345) is implemented, it is the product team’s responsibility to review test results and address any failures before release.
+
+### Suitable for upstream communities

--- a/pipelines/deploy-fbc-operator/0.1/deploy-fbc-operator.yaml
+++ b/pipelines/deploy-fbc-operator/0.1/deploy-fbc-operator.yaml
@@ -2,6 +2,8 @@ apiVersion: tekton.dev/v1
 kind: Pipeline
 metadata:
   name: deploy-fbc-operator
+  labels:
+    upstream-usable: "true"
 spec:
   description: |
     The deploy-fbc-operator pipeline automates the provisioning of a EaaS Hypershift cluster and the deployment of an operator from a given FBC (File-Based Catalog) fragment.

--- a/pipelines/deploy-fbc-operator/0.2/README.MD
+++ b/pipelines/deploy-fbc-operator/0.2/README.MD
@@ -214,3 +214,5 @@ Once your FBC component is built, the `deploy-fbc-operator` pipeline will be tri
 Currently, pipeline failures only block the auto-release of the Snapshot. They do *not* prevent users from manually releasing.
 
 Until [KONFLUX-7345](https://issues.redhat.com/browse/KONFLUX-7345) is implemented, it is the product team’s responsibility to review test results and address any failures before release.
+
+### Suitable for upstream communities

--- a/pipelines/deploy-fbc-operator/0.2/deploy-fbc-operator.yaml
+++ b/pipelines/deploy-fbc-operator/0.2/deploy-fbc-operator.yaml
@@ -2,6 +2,8 @@ apiVersion: tekton.dev/v1
 kind: Pipeline
 metadata:
   name: deploy-fbc-operator
+  labels:
+    upstream-usable: "true"
 spec:
   description: |
     The deploy-fbc-operator pipeline automates the provisioning of a EaaS Hypershift cluster and the deployment of an operator from a given FBC (File-Based Catalog) fragment.

--- a/stepactions/analyze-test-results/0.1/README.md
+++ b/stepactions/analyze-test-results/0.1/README.md
@@ -14,3 +14,4 @@ The command then tries to identify the cause of the failure and provides the res
 |e2e-log-name|The name of the log from running tests|e2e-tests.log|true|
 |cluster-provision-log-name|The name of the log from provisioning a testing cluster|cluster-provision.log|true|
 
+### Suitable for upstream communities

--- a/stepactions/analyze-test-results/0.1/analyze-test-results.yaml
+++ b/stepactions/analyze-test-results/0.1/analyze-test-results.yaml
@@ -2,6 +2,8 @@ apiVersion: tekton.dev/v1alpha1
 kind: StepAction
 metadata:
   name: analyze-test-results
+  labels:
+    upstream-usable: "true"
 spec:
   description: >-
     This StepAction runs "analyze-test-results" command from qe-tools binary against supplied

--- a/stepactions/bundles/get-unreleased-bundle/0.1/README.MD
+++ b/stepactions/bundles/get-unreleased-bundle/0.1/README.MD
@@ -56,3 +56,5 @@ spec:
         - name: channelName
           value: $(params.channelName)
 ```
+
+### Not suitable for upstream communities

--- a/stepactions/bundles/get-unreleased-bundle/0.1/get-unreleased-bundle.yaml
+++ b/stepactions/bundles/get-unreleased-bundle/0.1/get-unreleased-bundle.yaml
@@ -2,6 +2,8 @@ apiVersion: tekton.dev/v1beta1
 kind: StepAction
 metadata:
   name: get-unreleased-bundle
+  labels:
+    upstream-usable: "false"
 spec:
   description: >-
     This StepAction retrieves the highest bundle version from a specified package, channel, and unreleased bundles list in the provided FBC fragment.

--- a/stepactions/bundles/install-operator/0.1/README.MD
+++ b/stepactions/bundles/install-operator/0.1/README.MD
@@ -58,3 +58,5 @@ spec:
         - name: channelName
           value: $(params.channelName)
 ```
+
+### Suitable for upstream communities

--- a/stepactions/bundles/install-operator/0.1/install-operator.yaml
+++ b/stepactions/bundles/install-operator/0.1/install-operator.yaml
@@ -2,6 +2,8 @@ apiVersion: tekton.dev/v1beta1
 kind: StepAction
 metadata:
   name: install-operator
+  labels:
+    upstream-usable: "true"
 spec:
   description: |
     This StepAction installs an operator from a provided FBC fragment.

--- a/stepactions/bundles/pick-cluster-arch/0.1/README.MD
+++ b/stepactions/bundles/pick-cluster-arch/0.1/README.MD
@@ -39,3 +39,5 @@ spec:
         - name: bundleImage
           value: $(params.bundleImage)
 ```
+
+### Suitable for upstream communities

--- a/stepactions/bundles/pick-cluster-arch/0.1/pick-cluster-arch.yaml
+++ b/stepactions/bundles/pick-cluster-arch/0.1/pick-cluster-arch.yaml
@@ -2,6 +2,8 @@ apiVersion: tekton.dev/v1beta1
 kind: StepAction
 metadata:
   name: pick-cluster-arch
+  labels:
+    upstream-usable: "true"
 spec:
   description: |
     This StepAction retrieves the supported architectures for a bundle by checking the "operatorframework.io/arch" labels on the bundle CSV.

--- a/stepactions/bundles/pick-cluster-version/0.1/README.MD
+++ b/stepactions/bundles/pick-cluster-version/0.1/README.MD
@@ -54,3 +54,5 @@ spec:
         - name: clusterVersions
           value: ["$(steps.get-supported-versions.results.versions[*])"]
 ```
+
+### Suitable for upstream communities

--- a/stepactions/bundles/pick-cluster-version/0.1/pick-cluster-version.yaml
+++ b/stepactions/bundles/pick-cluster-version/0.1/pick-cluster-version.yaml
@@ -2,6 +2,8 @@ apiVersion: tekton.dev/v1beta1
 kind: StepAction
 metadata:
   name: pick-cluster-version
+  labels:
+    upstream-usable: "true"
 spec:
   description: >-
     This StepAction selects a cluster version for provisioning. It determines the target OCP version of an FBC fragment.

--- a/stepactions/fail-if-any-step-failed/0.1/README.md
+++ b/stepactions/fail-if-any-step-failed/0.1/README.md
@@ -65,3 +65,5 @@ spec:
           - name: pathInRepo
             value: stepactions/fail-if-any-step-failed/0.1/fail-if-any-step-failed.yaml
 ```
+
+### Suitable for upstream communities

--- a/stepactions/fail-if-any-step-failed/0.1/fail-if-any-step-failed.yaml
+++ b/stepactions/fail-if-any-step-failed/0.1/fail-if-any-step-failed.yaml
@@ -2,6 +2,8 @@ apiVersion: tekton.dev/v1alpha1
 kind: StepAction
 metadata:
   name: fail-if-any-step-failed
+  labels:
+    upstream-usable: "true"
 spec:
   description: |
     This StepAction searches for exit codes (/tekton/steps/<step-name>/exitCode) in each step within the Task and fails if it detects that any `exitCode != "0"`

--- a/stepactions/gather-cluster-resources/0.1/README.md
+++ b/stepactions/gather-cluster-resources/0.1/README.md
@@ -58,3 +58,5 @@ have the `oc login` command:
                 #!/bin/bash
                 ls -la /workspace/artifact-gathering
 ```
+
+### Suitable for upstream communities

--- a/stepactions/gather-cluster-resources/0.1/gather-cluster-resources.yaml
+++ b/stepactions/gather-cluster-resources/0.1/gather-cluster-resources.yaml
@@ -2,6 +2,8 @@ apiVersion: tekton.dev/v1alpha1
 kind: StepAction
 metadata:
   name: gather-cluster-resources
+  labels:
+    upstream-usable: "true"
 spec:
   description: >-
     This StepAction executes the gather extra script that gathers konflux related resources from the cluster.

--- a/stepactions/sealights/create-test-session/0.1/README.md
+++ b/stepactions/sealights/create-test-session/0.1/README.md
@@ -57,3 +57,5 @@ spec:
         - name: test-stage
           value: $(params.test-stage)
 ```
+
+### Not suitable for upstream communities

--- a/stepactions/sealights/create-test-session/0.1/create-test-session.yaml
+++ b/stepactions/sealights/create-test-session/0.1/create-test-session.yaml
@@ -2,6 +2,8 @@ apiVersion: tekton.dev/v1alpha1
 kind: StepAction
 metadata:
   name: create-test-session
+  labels:
+    upstream-usable: "false"
 spec:
   description: |
     The `create-test-session` initializes a new Sealights test session by creating a session ID using the Sealights API and storing it for later use in the pipeline.

--- a/stepactions/sealights/upload-ginkgo-results/0.1/README.md
+++ b/stepactions/sealights/upload-ginkgo-results/0.1/README.md
@@ -75,3 +75,5 @@ spec:
         - name: test-session-id
           value: $(params.test-session-id)
 ```
+
+### Not suitable for upstream communities

--- a/stepactions/sealights/upload-ginkgo-results/0.1/upload-ginkgo-results.yaml
+++ b/stepactions/sealights/upload-ginkgo-results/0.1/upload-ginkgo-results.yaml
@@ -2,6 +2,8 @@ apiVersion: tekton.dev/v1alpha1
 kind: StepAction
 metadata:
   name: upload-ginkgo-results
+  labels:
+    upstream-usable: "false"
 spec:
   description: |
     "This Tekton StepAction uploads Ginkgo test results to Sealights. It creates a Sealights test session

--- a/stepactions/secure-push-oci/0.1/README.md
+++ b/stepactions/secure-push-oci/0.1/README.md
@@ -13,3 +13,5 @@ If the tag exists, it will update the existing content with the content of the w
 |oci-ref|Full OCI artifact reference in a format "quay.io/org/repo:tag"||true|
 |oci-tag-expiration|OCI artifact tag expiration|1y|false|
 |always-pass|Even if execution of the stepaction's script fails, do not fail the step|"true"|false|
+
+### Suitable for upstream communities

--- a/stepactions/secure-push-oci/0.1/secure-push-oci.yaml
+++ b/stepactions/secure-push-oci/0.1/secure-push-oci.yaml
@@ -2,6 +2,8 @@ apiVersion: tekton.dev/v1alpha1
 kind: StepAction
 metadata:
   name: secure-push-oci
+  labels:
+    upstream-usable: "true"
 spec:
   description: |
     This StepAction scans specified directory (workingDir) using [leaktk-scanner CLI](https://github.com/leaktk/scanner)

--- a/tasks/bundles/verify-image-sources/0.1/README.MD
+++ b/tasks/bundles/verify-image-sources/0.1/README.MD
@@ -50,3 +50,6 @@ spec:
           value: $(params.bundleImage)
         - name: scorecardConfigImages
           value: $(params.scorecardConfigImages)
+```
+
+### Not suitable for upstream communities

--- a/tasks/bundles/verify-image-sources/0.1/verify-image-sources.yaml
+++ b/tasks/bundles/verify-image-sources/0.1/verify-image-sources.yaml
@@ -3,6 +3,8 @@ apiVersion: tekton.dev/v1
 kind: Task
 metadata:
   name: verify-image-sources
+  labels:
+    upstream-usable: "false"
 spec:
   description: |
     The image source test collects all image pull events on the testing cluster, starting from the operator's deployment on the cluster until the end of testing.

--- a/tasks/check-if-e2e-irrelevant/0.1/README.md
+++ b/tasks/check-if-e2e-irrelevant/0.1/README.md
@@ -24,3 +24,4 @@ sets the result accordingly.
 
 It returns "false" if the PR is e2e relevant, otherwise it returns "true" (including any error occurs).
 
+### Suitable for upstream communities

--- a/tasks/check-if-e2e-irrelevant/0.1/check-if-e2e-irrelevant.yaml
+++ b/tasks/check-if-e2e-irrelevant/0.1/check-if-e2e-irrelevant.yaml
@@ -3,6 +3,8 @@ apiVersion: tekton.dev/v1
 kind: Task
 metadata:
   name: check-if-e2e-irrelevant
+  labels:
+    upstream-usable: "true"
 spec:
   description: |
     This task checks if the files changed in the pull request are all irrelevant to the e2e tests.

--- a/tasks/konflux-ci/deploy/0.1/Readme.md
+++ b/tasks/konflux-ci/deploy/0.1/Readme.md
@@ -88,3 +88,6 @@ metadata:
 type: Opaque
 data:
   kubeconfig: <base64-encoded-kubeconfig>
+```
+
+### Suitable for upstream communities

--- a/tasks/konflux-ci/deploy/0.1/deploy-konflux-ci.yaml
+++ b/tasks/konflux-ci/deploy/0.1/deploy-konflux-ci.yaml
@@ -6,6 +6,7 @@ metadata:
   labels:
     konflux-ci/kind: "true"
     app.kubernetes.io/version: "0.1"
+    upstream-usable: "true"
   annotations:
     tekton.dev/pipelines.minVersion: "0.44.x"
     tekton.dev/tags: konflux

--- a/tasks/konflux-ci/deploy/0.2/Readme.md
+++ b/tasks/konflux-ci/deploy/0.2/Readme.md
@@ -91,3 +91,6 @@ metadata:
 type: Opaque
 data:
   kubeconfig: <base64-encoded-kubeconfig>
+```
+
+### Suitable for upstream communities

--- a/tasks/konflux-ci/deploy/0.2/deploy-konflux-ci.yaml
+++ b/tasks/konflux-ci/deploy/0.2/deploy-konflux-ci.yaml
@@ -6,6 +6,7 @@ metadata:
   labels:
     konflux-ci/kind: "true"
     app.kubernetes.io/version: "0.2"
+    upstream-usable: "true"
   annotations:
     tekton.dev/pipelines.minVersion: "0.44.x"
     tekton.dev/tags: konflux

--- a/tasks/konflux-ci/deploy/0.3/Readme.md
+++ b/tasks/konflux-ci/deploy/0.3/Readme.md
@@ -129,3 +129,5 @@ data:
   gh-app-webhook-secret: <Webhook secret of the GitHub App>
   smee-channel: <smee.io URL used for redirecting events sent by GitHub App>
 ```
+
+### Suitable for upstream communities

--- a/tasks/konflux-ci/deploy/0.3/deploy-konflux-ci.yaml
+++ b/tasks/konflux-ci/deploy/0.3/deploy-konflux-ci.yaml
@@ -6,6 +6,7 @@ metadata:
   labels:
     konflux-ci/kind: "true"
     app.kubernetes.io/version: "0.3"
+    upstream-usable: "true"
   annotations:
     tekton.dev/pipelines.minVersion: "0.44.x"
     tekton.dev/tags: konflux

--- a/tasks/linters/checkton/0.1/README.md
+++ b/tasks/linters/checkton/0.1/README.md
@@ -62,3 +62,5 @@ spec:
         - name: git-revision
           value: "$(tasks.test-metadata.results.git-revision)"
 ```
+
+### Suitable for upstream communities

--- a/tasks/linters/checkton/0.1/checkton.yaml
+++ b/tasks/linters/checkton/0.1/checkton.yaml
@@ -2,6 +2,8 @@ apiVersion: tekton.dev/v1
 kind: Task
 metadata:
   name: checkton
+  labels:
+    upstream-usable: "true"
 spec:
   params:
   - name: git-url

--- a/tasks/linters/hadolint/0.1/README.md
+++ b/tasks/linters/hadolint/0.1/README.md
@@ -74,3 +74,5 @@ spec:
         - name: dockerfile-path
           value: "./Dockerfile"
 ```
+
+### Suitable for upstream communities

--- a/tasks/linters/hadolint/0.1/hadolint.yaml
+++ b/tasks/linters/hadolint/0.1/hadolint.yaml
@@ -2,6 +2,8 @@ apiVersion: tekton.dev/v1
 kind: Task
 metadata:
   name: hadolint
+  labels:
+    upstream-usable: "true"
 spec:
   description: |
     The Hadolint task runs the Hadolint (Haskell Dockerfile Linter) Docker linting tool on Dockerfiles/Containerfiles

--- a/tasks/linters/shellcheck/0.1/README.md
+++ b/tasks/linters/shellcheck/0.1/README.md
@@ -65,3 +65,5 @@ spec:
         - name: git-revision
           value: "$(tasks.test-metadata.results.git-revision)"
 ```
+
+### Suitable for upstream communities

--- a/tasks/linters/shellcheck/0.1/shellcheck.yaml
+++ b/tasks/linters/shellcheck/0.1/shellcheck.yaml
@@ -3,6 +3,8 @@ apiVersion: tekton.dev/v1beta1
 kind: Task
 metadata:
   name: shellcheck
+  labels:
+    upstream-usable: "true"
 spec:
   description: |
     This task performs a ShellCheck analysis on shell scripts in a given Git repository.

--- a/tasks/linters/yamllint/0.1/README.md
+++ b/tasks/linters/yamllint/0.1/README.md
@@ -65,3 +65,5 @@ spec:
         - name: git-revision
           value: "$(tasks.test-metadata.results.git-revision)"
 ```
+
+### Suitable for upstream communities

--- a/tasks/linters/yamllint/0.1/yaml-lint.yaml
+++ b/tasks/linters/yamllint/0.1/yaml-lint.yaml
@@ -3,6 +3,8 @@ apiVersion: tekton.dev/v1beta1
 kind: Task
 metadata:
   name: yaml-lint
+  labels:
+    upstream-usable: "true"
 spec:
   description: |
     This task performs YAML linting on YAML files in a given Git repository.

--- a/tasks/mapt-oci/kind-aws-spot/deprovision/0.1/Readme.md
+++ b/tasks/mapt-oci/kind-aws-spot/deprovision/0.1/Readme.md
@@ -155,3 +155,5 @@ Ensure this is a properly formatted `.dockerconfigjson` file and base64-encoded.
 ## ⚠️ Notes
 
 - **Graceful Failures**: Most steps have `onError: continue`, which ensures that even in failed pipelines, diagnostics can be gathered before final cleanup.
+
+### Suitable for upstream communities

--- a/tasks/mapt-oci/kind-aws-spot/deprovision/0.1/kind-aws-deprovision.yaml
+++ b/tasks/mapt-oci/kind-aws-spot/deprovision/0.1/kind-aws-deprovision.yaml
@@ -5,6 +5,7 @@ metadata:
   name: kind-aws-deprovision
   labels:
     app.kubernetes.io/version: "0.1"
+    upstream-usable: "true"
   annotations:
     tekton.dev/pipelines.minVersion: "0.44.x"
     tekton.dev/categories: infrastructure

--- a/tasks/mapt-oci/kind-aws-spot/provision/0.1/Readme.md
+++ b/tasks/mapt-oci/kind-aws-spot/provision/0.1/Readme.md
@@ -154,3 +154,5 @@ roleRef:
 ```
 
 > **Note:** Without these permissions, the task will fail when attempting to create the kubeconfig Secret.
+
+### Suitable for upstream communities

--- a/tasks/mapt-oci/kind-aws-spot/provision/0.1/kind-aws-provision.yaml
+++ b/tasks/mapt-oci/kind-aws-spot/provision/0.1/kind-aws-provision.yaml
@@ -5,6 +5,7 @@ metadata:
   name: kind-aws-provision
   labels:
     app.kubernetes.io/version: "0.1"
+    upstream-usable: "true"
   annotations:
     tekton.dev/pipelines.minVersion: "0.44.x"
     tekton.dev/categories: infrastructure

--- a/tasks/mapt-oci/kind-aws-spot/provision/0.2/Readme.md
+++ b/tasks/mapt-oci/kind-aws-spot/provision/0.2/Readme.md
@@ -157,3 +157,5 @@ roleRef:
 ```
 
 > **Note:** Without these permissions, the task will fail when attempting to create the kubeconfig Secret.
+
+### Suitable for upstream communities

--- a/tasks/mapt-oci/kind-aws-spot/provision/0.2/kind-aws-provision.yaml
+++ b/tasks/mapt-oci/kind-aws-spot/provision/0.2/kind-aws-provision.yaml
@@ -5,6 +5,7 @@ metadata:
   name: kind-aws-provision
   labels:
     app.kubernetes.io/version: "0.2"
+    upstream-usable: "true"
   annotations:
     tekton.dev/pipelines.minVersion: "0.44.x"
     tekton.dev/categories: infrastructure

--- a/tasks/pull-request-comment/0.1/README.md
+++ b/tasks/pull-request-comment/0.1/README.md
@@ -41,3 +41,5 @@ This task is useful in Konflux CI workflows where feedback on pull request testi
 ## Results
 
 This task does not produce any output results.
+
+### Suitable for upstream communities

--- a/tasks/pull-request-comment/0.1/pull-request-comment.yaml
+++ b/tasks/pull-request-comment/0.1/pull-request-comment.yaml
@@ -5,6 +5,7 @@ metadata:
   name: pull-request-commenter
   labels:
     app.kubernetes.io/version: "0.1"
+    upstream-usable: "true"
   annotations:
     tekton.dev/pipelines.minVersion: 0.12.1
     tekton.dev/tags: konflux

--- a/tasks/pull-request-comment/0.2/README.md
+++ b/tasks/pull-request-comment/0.2/README.md
@@ -62,3 +62,5 @@ If the parameter is empty or not provided, no artifact browser link will be incl
 - The task requires a GitHub token (stored in a secret) to authenticate and post comments.
 - Ensure ORAS is installed if you need to retrieve test artifacts.
 - Use `/retest` in the PR comment to trigger a rerun of failed tests.
+
+### Suitable for upstream communities

--- a/tasks/pull-request-comment/0.2/pull-request-comment.yaml
+++ b/tasks/pull-request-comment/0.2/pull-request-comment.yaml
@@ -5,6 +5,7 @@ metadata:
   name: pull-request-commenter
   labels:
     app.kubernetes.io/version: "0.1"
+    upstream-usable: "true"
   annotations:
     tekton.dev/pipelines.minVersion: 0.12.1
     tekton.dev/tags: konflux

--- a/tasks/rosa/hosted-cp/rosa-hcp-deprovision/0.1/README.md
+++ b/tasks/rosa/hosted-cp/rosa-hcp-deprovision/0.1/README.md
@@ -114,3 +114,5 @@ This task can be included in a Tekton pipeline to ensure proper cleanup and arti
 
 - Ensure that the `konflux-test-infra` secret contains the necessary AWS credentials and ROSA tokens.
 - Artifact storage requires authentication to an OCI container registry.
+
+### Not suitable for upstream communities

--- a/tasks/rosa/hosted-cp/rosa-hcp-deprovision/0.1/rosa-hcp-deprovision.yaml
+++ b/tasks/rosa/hosted-cp/rosa-hcp-deprovision/0.1/rosa-hcp-deprovision.yaml
@@ -4,6 +4,7 @@ metadata:
   name: collect-artifacts-deprovision-rosa
   labels:
     app.kubernetes.io/version: "0.1"
+    upstream-usable: "false"
   annotations:
     tekton.dev/pipelines.minVersion: 0.12.1
     tekton.dev/tags: konflux

--- a/tasks/rosa/hosted-cp/rosa-hcp-deprovision/0.2/README.md
+++ b/tasks/rosa/hosted-cp/rosa-hcp-deprovision/0.2/README.md
@@ -114,3 +114,5 @@ This task can be included in a Tekton pipeline to ensure proper cleanup and arti
 
 - Ensure that the `konflux-test-infra` secret contains the necessary AWS credentials and ROSA tokens.
 - Artifact storage requires authentication to an OCI container registry.
+
+### Not suitable for upstream communities

--- a/tasks/rosa/hosted-cp/rosa-hcp-deprovision/0.2/rosa-hcp-deprovision.yaml
+++ b/tasks/rosa/hosted-cp/rosa-hcp-deprovision/0.2/rosa-hcp-deprovision.yaml
@@ -4,6 +4,7 @@ metadata:
   name: collect-artifacts-deprovision-rosa
   labels:
     app.kubernetes.io/version: "0.1"
+    upstream-usable: "false"
   annotations:
     tekton.dev/pipelines.minVersion: 0.12.1
     tekton.dev/tags: konflux

--- a/tasks/rosa/hosted-cp/rosa-hcp-metadata/0.1/README.md
+++ b/tasks/rosa/hosted-cp/rosa-hcp-metadata/0.1/README.md
@@ -68,3 +68,5 @@ Then, in a subsequent task (e.g., `rosa-hcp-provision`), reference the generated
 - This ensures unique cluster names in different pipeline runs.
 - The fixed `kx` prefix helps in identifying clusters created via Tekton automation.
 - The cluster name is capped at a reasonable length to comply with OpenShift and AWS naming conventions.
+
+### Not suitable for upstream communities

--- a/tasks/rosa/hosted-cp/rosa-hcp-metadata/0.1/rosa-hcp-metadata.yaml
+++ b/tasks/rosa/hosted-cp/rosa-hcp-metadata/0.1/rosa-hcp-metadata.yaml
@@ -2,6 +2,8 @@ apiVersion: tekton.dev/v1
 kind: Task
 metadata:
   name: rosa-hcp-metadata
+  labels:
+    upstream-usable: "false"
 spec:
   description: |
     The `rosa-hcp-metadata` task generates a unique name for an OpenShift cluster using a predefined prefix and a randomly generated hexadecimal string.

--- a/tasks/rosa/hosted-cp/rosa-hcp-provision/0.1/README.md
+++ b/tasks/rosa/hosted-cp/rosa-hcp-provision/0.1/README.md
@@ -66,3 +66,5 @@ The `rosa-hcp-provision` Tekton task automates the creation and provisioning of 
         - name: hcp-config-secret
           value: "$(params.hcp-config-secret)"
 ```
+
+### Not suitable for upstream communities

--- a/tasks/rosa/hosted-cp/rosa-hcp-provision/0.1/rosa-hcp-provision.yaml
+++ b/tasks/rosa/hosted-cp/rosa-hcp-provision/0.1/rosa-hcp-provision.yaml
@@ -2,6 +2,8 @@ apiVersion: tekton.dev/v1
 kind: Task
 metadata:
   name: rosa-hcp-provision
+  labels:
+    upstream-usable: "false"
 spec:
   description: |
     The `rosa-hcp-provision` task automates the creation and provisioning of an ephemeral OpenShift cluster using Red Hat OpenShift on AWS (ROSA) with Hosted Control Planes (HCP).

--- a/tasks/rosa/hosted-cp/rosa-hcp-provision/0.2/README.md
+++ b/tasks/rosa/hosted-cp/rosa-hcp-provision/0.2/README.md
@@ -101,3 +101,5 @@ This task can be integrated into a Tekton pipeline to automate the provisioning 
 - Ensure the `konflux-test-infra` secret contains valid AWS credentials and ROSA tokens.
 - Cluster provisioning may take several minutes depending on AWS region and workload.
 - Artifacts and logs are securely stored in the provided OCI container registry.
+
+### Not suitable for upstream communities

--- a/tasks/rosa/hosted-cp/rosa-hcp-provision/0.2/rosa-hcp-provision.yaml
+++ b/tasks/rosa/hosted-cp/rosa-hcp-provision/0.2/rosa-hcp-provision.yaml
@@ -4,6 +4,7 @@ metadata:
   name: rosa-hcp-provision
   labels:
     app.kubernetes.io/version: "0.1"
+    upstream-usable: "false"
   annotations:
     tekton.dev/pipelines.minVersion: 0.12.1
     tekton.dev/tags: konflux

--- a/tasks/sealights/sealights-get-refs/0.1/README.md
+++ b/tasks/sealights/sealights-get-refs/0.1/README.md
@@ -143,3 +143,5 @@ Add the following snippet after `prefetch-dependencies`:
       values:
         - "true"
 ```
+
+### Not suitable for upstream communities

--- a/tasks/sealights/sealights-get-refs/0.1/sealights-get-refs.yaml
+++ b/tasks/sealights/sealights-get-refs/0.1/sealights-get-refs.yaml
@@ -6,6 +6,7 @@ metadata:
   labels:
     konflux-ci/sealights: "true"
     app.kubernetes.io/version: "0.1"
+    upstream-usable: "false"
   annotations:
     tekton.dev/pipelines.minVersion: 0.12.1
     tekton.dev/tags: konflux

--- a/tasks/sprayproxy/sprayproxy-deprovision/0.1/README.md
+++ b/tasks/sprayproxy/sprayproxy-deprovision/0.1/README.md
@@ -93,3 +93,5 @@ spec:
 - OpenShift CLI (`oc`) installed
 - Valid OpenShift cluster credentials
 - A running SprayProxy server in one of your clusters
+
+### Not suitable for upstream communities

--- a/tasks/sprayproxy/sprayproxy-deprovision/0.1/sprayproxy-deprovision.yaml
+++ b/tasks/sprayproxy/sprayproxy-deprovision/0.1/sprayproxy-deprovision.yaml
@@ -5,6 +5,7 @@ metadata:
   name: sprayproxy-unregister-server
   labels:
     app.kubernetes.io/version: "0.1"
+    upstream-usable: "false"
   annotations:
     tekton.dev/pipelines.minVersion: 0.12.1
     tekton.dev/tags: konflux

--- a/tasks/sprayproxy/sprayproxy-provision/0.1/README.md
+++ b/tasks/sprayproxy/sprayproxy-provision/0.1/README.md
@@ -93,3 +93,5 @@ spec:
 - OpenShift CLI (`oc`) installed
 - Valid OpenShift cluster credentials
 - A running SprayProxy server in one of your clusters
+
+### Not suitable for upstream communities

--- a/tasks/sprayproxy/sprayproxy-provision/0.1/sprayproxy-provision.yaml
+++ b/tasks/sprayproxy/sprayproxy-provision/0.1/sprayproxy-provision.yaml
@@ -5,6 +5,7 @@ metadata:
   name: sprayproxy-register-server
   labels:
     app.kubernetes.io/version: "0.1"
+    upstream-usable: "false"
   annotations:
     tekton.dev/pipelines.minVersion: 0.12.1
     tekton.dev/tags: konflux

--- a/tasks/store-pipeline-status/0.1/README.md
+++ b/tasks/store-pipeline-status/0.1/README.md
@@ -51,3 +51,5 @@ spec:
 ## Results
 
 This task does not produce any output results.
+
+### Suitable for upstream communities

--- a/tasks/store-pipeline-status/0.1/store-pipeline-status.yaml
+++ b/tasks/store-pipeline-status/0.1/store-pipeline-status.yaml
@@ -5,6 +5,7 @@ metadata:
   name: store-pipeline-status
   labels:
     app.kubernetes.io/version: "0.1"
+    upstream-usable: "true"
   annotations:
     tekton.dev/pipelines.minVersion: 0.12.1
     tekton.dev/tags: konflux

--- a/tasks/test-metadata/0.1/README.md
+++ b/tasks/test-metadata/0.1/README.md
@@ -96,3 +96,5 @@ spec:
         - name: oras-container
           value: "<your-oras-container-without-tag>"
 ```
+
+### Suitable for upstream communities

--- a/tasks/test-metadata/0.1/test-metadata.yaml
+++ b/tasks/test-metadata/0.1/test-metadata.yaml
@@ -5,6 +5,7 @@ metadata:
   name: test-metadata
   labels:
     app.kubernetes.io/version: "0.1"
+    upstream-usable: "true"
   annotations:
     tekton.dev/pipelines.minVersion: 0.12.1
     tekton.dev/tags: konflux

--- a/tasks/test-metadata/0.2/README.md
+++ b/tasks/test-metadata/0.2/README.md
@@ -111,3 +111,6 @@ spec:
           value: "<your-snapshot-json>"
         - name: test-name
           value: "<your-test-name>"
+```
+
+### Suitable for upstream communities

--- a/tasks/test-metadata/0.2/test-metadata.yaml
+++ b/tasks/test-metadata/0.2/test-metadata.yaml
@@ -5,6 +5,7 @@ metadata:
   name: test-metadata
   labels:
     app.kubernetes.io/version: "0.2"
+    upstream-usable: "true"
   annotations:
     tekton.dev/pipelines.minVersion: 0.12.1
     tekton.dev/tags: konflux

--- a/tasks/test-metadata/0.3/README.md
+++ b/tasks/test-metadata/0.3/README.md
@@ -196,3 +196,5 @@ spec:
 - **0.1**: Individual result outputs for specific metadata values
 - **0.2**: Consolidated job-spec approach with prefetch functionality
 - **0.3**: Combined approach with both individual and consolidated results, plus enhanced git information 
+
+### Suitable for upstream communities

--- a/tasks/test-metadata/0.3/test-metadata.yaml
+++ b/tasks/test-metadata/0.3/test-metadata.yaml
@@ -5,6 +5,7 @@ metadata:
   name: test-metadata
   labels:
     app.kubernetes.io/version: "0.3"
+    upstream-usable: "true"
   annotations:
     tekton.dev/pipelines.minVersion: 0.12.1
     tekton.dev/tags: konflux

--- a/tasks/test-results/datarouter/0.1/README.md
+++ b/tasks/test-results/datarouter/0.1/README.md
@@ -257,3 +257,5 @@ spec:
 
 - **Image:** [quay.io/dno/droute](https://quay.io/repository/dno/droute?tab=info)
 - **Data Router User's Guide:** [Data Router User's Guide](https://spaces.redhat.com/x/7VbhB)
+
+### Suitable for upstream communities

--- a/tasks/test-results/datarouter/0.1/datarouter.yaml
+++ b/tasks/test-results/datarouter/0.1/datarouter.yaml
@@ -4,6 +4,7 @@ metadata:
   name: datarouter
   labels:
     app.kubernetes.io/version: "0.1"
+    upstream-usable: "true"
   annotations:
     tekton.dev/pipelines.minVersion: 0.12.1
     tekton.dev/tags: konflux

--- a/tasks/triggers/jenkins/0.1/README.md
+++ b/tasks/triggers/jenkins/0.1/README.md
@@ -59,3 +59,5 @@ spec:
         - name: JOB_NAME
           value: <your Jenkins job full project name>
 ```
+
+### Suitable for upstream communities

--- a/tasks/triggers/jenkins/0.1/trigger-jenkins-job.yaml
+++ b/tasks/triggers/jenkins/0.1/trigger-jenkins-job.yaml
@@ -4,6 +4,7 @@ metadata:
   name: trigger-jenkins-job
   labels:
     app.kubernetes.io/version: "0.1"
+    upstream-usable: "true"
   annotations:
     tekton.dev/pipelines.minVersion: 0.12.1
     tekton.dev/tags: konflux

--- a/tasks/wait-for-integration-tests/0.1/README.md
+++ b/tasks/wait-for-integration-tests/0.1/README.md
@@ -45,3 +45,5 @@ spec:
 ## Results
 
 This task does not produce any output results.
+
+### Suitable for upstream communities

--- a/tasks/wait-for-integration-tests/0.1/wait-for-integration-tests.yaml
+++ b/tasks/wait-for-integration-tests/0.1/wait-for-integration-tests.yaml
@@ -5,6 +5,7 @@ metadata:
   name: wait-for-integration-tests
   labels:
     app.kubernetes.io/version: "0.1"
+    upstream-usable: "true"
   annotations:
     tekton.dev/pipelines.minVersion: 0.12.1
     tekton.dev/tags: konflux


### PR DESCRIPTION
Adds labels to README.md and yaml files defining the task, stepaction, or pipeline as suitable for upstream use or is for internal use only.