### PR TITLE
KFLUXSPRT-7380 - Add optional settings for slack notifications on fbc pipeline

### DIFF
--- a/pipelines/deploy-fbc-operator/0.1/README.MD
+++ b/pipelines/deploy-fbc-operator/0.1/README.MD
@@ -64,6 +64,8 @@ The pipeline consists of the following tasks:
 |REPO_TOKEN| Name of the Kubernetes Secret that contains the access token for a private GitHub or GitLab repository| ""| false|
 |REPO_KEY| Key within the Secret's "data" field that holds the GitHub/GitLab access token| ""| false|
 |PATH_TO_MIRROR_SET| Path to where the image digest mirror set is saved in the repository| ".tekton/images-mirror-set.yaml"| false|
+|SLACK_SECRET_NAME| Name of the secret containing the Slack webhook URL. Leave empty to disable Slack notifications| ""| false|
+|SLACK_KEY_NAME| Key name within the secret that contains the Slack webhook URL| "webhook_url"| false|
 
 ## Pipeline Usage Guide
 
@@ -83,6 +85,8 @@ Open a merge request (MR) to your [tenants-config](https://gitlab.cee.redhat.com
 - `spec.params[4].value`  -> REPO_TOKEN (Optional)
 - `spec.params[5].value`  -> REPO_KEY (Optional)
 - `spec.params[6].value`  -> PATH_TO_MIRROR_SET (Optional)
+- `spec.params[7].value`  -> SLACK_SECRET_NAME (Optional)
+- `spec.params[8].value`  -> SLACK_KEY_NAME (Optional)
 
 ```yaml
 apiVersion: appstudio.redhat.com/v1beta2
@@ -112,6 +116,10 @@ spec:
       value: "git-auth-key"
     - name: PATH_TO_MIRROR_SET
       value: "config/imageDigestMirrorSet.yaml"
+    - name: SLACK_SECRET_NAME
+      value: "slack-webhook-secret"
+    - name: SLACK_KEY_NAME
+      value: "webhook_url"
   resolverRef:
     params:
       - name: url
@@ -183,6 +191,31 @@ In the example above, the `REPO_KEY` value should be `gitlab-auth-token`.
 #### PATH_TO_MIRROR_SET (Optional)
 
 Path to where the image digest mirror set is saved in the repository.
+
+#### SLACK_SECRET_NAME (Optional)
+
+Name of the secret containing the Slack webhook URL. Leave this parameter empty to disable Slack notifications.
+
+When a Slack webhook secret is provided, the pipeline will send a notification to the configured Slack channel if the pipeline fails.
+
+Example:
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: slack-webhook-secret
+  namespace: sample-tenant
+type: Opaque
+data:
+  webhook_url: <BASE64_ENCODED_WEBHOOK_URL>
+```
+
+#### SLACK_KEY_NAME (Optional)
+
+Key name within the secret that contains the Slack webhook URL. Defaults to `webhook_url`.
+
+This parameter specifies which key in the secret contains the actual Slack webhook URL. In the example above, the `SLACK_KEY_NAME` value should be `webhook_url`.
 
 ### What Happens Next
 

--- a/pipelines/deploy-fbc-operator/0.1/deploy-fbc-operator.yaml
+++ b/pipelines/deploy-fbc-operator/0.1/deploy-fbc-operator.yaml
@@ -69,6 +69,14 @@ spec:
       name: PATH_TO_MIRROR_SET
       default: ".tekton/images-mirror-set.yaml"
       type: string
+    - description: Name of the secret containing the Slack webhook URL. Leave empty to disable Slack notifications.
+      name: SLACK_SECRET_NAME
+      default: ""
+      type: string
+    - description: Key name within the secret that contains the Slack webhook URL
+      name: SLACK_KEY_NAME
+      default: "webhook_url"
+      type: string
   tasks:
     - name: parse-metadata
       taskRef:
@@ -921,3 +929,28 @@ spec:
           value: "$(tasks.get-unreleased-bundle.results.unreleasedBundle)"
         - name: scorecardConfigImages
           value: "$(tasks.fetch-config-files.results.scorecardConfigImages)"
+  finally:
+    - name: slack-webhook-notification
+      params:
+        - name: message
+          value: PipelineRun $(context.pipelineRun.name) failed
+        - name: secret-name
+          value: $(params.SLACK_SECRET_NAME)
+        - name: key-name
+          value: $(params.SLACK_KEY_NAME)
+      taskRef:
+        params:
+          - name: bundle
+            value: quay.io/konflux-ci/tekton-catalog/task-slack-webhook-notification:0.1
+          - name: name
+            value: slack-webhook-notification
+          - name: kind
+            value: Task
+        resolver: bundles
+      when:
+        - input: $(tasks.status)
+          operator: in
+          values: ["Failed"]
+        - input: $(params.SLACK_SECRET_NAME)
+          operator: notin
+          values: [""]

--- a/pipelines/deploy-fbc-operator/0.2/README.MD
+++ b/pipelines/deploy-fbc-operator/0.2/README.MD
@@ -80,6 +80,8 @@ The pipeline consists of the following tasks:
 |REPO_TOKEN| Name of the Kubernetes Secret that contains the access token for a private GitHub or GitLab repository| ""| false|
 |REPO_KEY| Key within the Secret's "data" field that holds the GitHub/GitLab access token| ""| false|
 |PATH_TO_MIRROR_SET| Path to where the image digest mirror set is saved in the repository| ".tekton/images-mirror-set.yaml"| false|
+|SLACK_SECRET_NAME| Name of the secret containing the Slack webhook URL. Leave empty to disable Slack notifications| ""| false|
+|SLACK_KEY_NAME| Key name within the secret that contains the Slack webhook URL| "webhook_url"| false|
 
 ## Pipeline Usage Guide
 
@@ -99,6 +101,8 @@ Open a merge request (MR) to your [tenants-config](https://gitlab.cee.redhat.com
 - `spec.params[4].value`  -> REPO_TOKEN (Optional)
 - `spec.params[5].value`  -> REPO_KEY (Optional)
 - `spec.params[6].value`  -> PATH_TO_MIRROR_SET (Optional)
+- `spec.params[7].value`  -> SLACK_SECRET_NAME (Optional)
+- `spec.params[8].value`  -> SLACK_KEY_NAME (Optional)
 
 ```yaml
 apiVersion: appstudio.redhat.com/v1beta2
@@ -128,6 +132,10 @@ spec:
       value: "git-auth-key"
     - name: PATH_TO_MIRROR_SET
       value: "config/imageDigestMirrorSet.yaml"
+    - name: SLACK_SECRET_NAME
+      value: "slack-webhook-secret"
+    - name: SLACK_KEY_NAME
+      value: "webhook_url"
   resolverRef:
     resourceKind: pipelinerun
     params:
@@ -200,6 +208,31 @@ In the example above, the `REPO_KEY` value should be `gitlab-auth-token`.
 #### PATH_TO_MIRROR_SET (Optional)
 
 Path to where the image digest mirror set is saved in the repository.
+
+#### SLACK_SECRET_NAME (Optional)
+
+Name of the secret containing the Slack webhook URL. Leave this parameter empty to disable Slack notifications.
+
+When a Slack webhook secret is provided, the pipeline will send a notification to the configured Slack channel if the pipeline fails.
+
+Example:
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: slack-webhook-secret
+  namespace: sample-tenant
+type: Opaque
+data:
+  webhook_url: <BASE64_ENCODED_WEBHOOK_URL>
+```
+
+#### SLACK_KEY_NAME (Optional)
+
+Key name within the secret that contains the Slack webhook URL. Defaults to `webhook_url`.
+
+This parameter specifies which key in the secret contains the actual Slack webhook URL. In the example above, the `SLACK_KEY_NAME` value should be `webhook_url`.
 
 ### What Happens Next
 

--- a/pipelines/deploy-fbc-operator/0.2/deploy-fbc-operator.yaml
+++ b/pipelines/deploy-fbc-operator/0.2/deploy-fbc-operator.yaml
@@ -69,6 +69,14 @@ spec:
       name: PATH_TO_MIRROR_SET
       default: ".tekton/images-mirror-set.yaml"
       type: string
+    - description: Name of the secret containing the Slack webhook URL. Leave empty to disable Slack notifications.
+      name: SLACK_SECRET_NAME
+      default: ""
+      type: string
+    - description: Key name within the secret that contains the Slack webhook URL
+      name: SLACK_KEY_NAME
+      default: "webhook_url"
+      type: string
   workspaces:
     - name: shared-data
   tasks:
@@ -924,3 +932,28 @@ spec:
           value: "$(tasks.get-unreleased-bundle.results.unreleasedBundle)"
         - name: scorecardConfigImages
           value: "$(tasks.fetch-config-files.results.scorecardConfigImages)"
+  finally:
+    - name: slack-webhook-notification
+      params:
+        - name: message
+          value: PipelineRun $(context.pipelineRun.name) failed
+        - name: secret-name
+          value: $(params.SLACK_SECRET_NAME)
+        - name: key-name
+          value: $(params.SLACK_KEY_NAME)
+      taskRef:
+        params:
+          - name: bundle
+            value: quay.io/konflux-ci/tekton-catalog/task-slack-webhook-notification:0.1
+          - name: name
+            value: slack-webhook-notification
+          - name: kind
+            value: Task
+        resolver: bundles
+      when:
+        - input: $(tasks.status)
+          operator: in
+          values: ["Failed"]
+        - input: $(params.SLACK_SECRET_NAME)
+          operator: notin
+          values: [""]


### PR DESCRIPTION
Pipeline Files (0.1 and 0.2):

  1. Added two new pipeline parameters:
      - SLACK_SECRET_NAME (default: "") - Name of the secret containing the Slack webhook URL
      - SLACK_KEY_NAME (default: "webhook_url") - Key within the secret containing the webhook
     URL
  
    2. Added a finally block:
      - Sends Slack notifications only when:
          - Any pipeline task fails
          - AND a SLACK_SECRET_NAME is provided (not empty)
      - Completely optional - won't cause issues if users don't configure it

  README.MD Files (0.1 and 0.2):

    1. Updated the parameters table to include the new Slack parameters
    2. Updated the spec.params instructions to include entries for spec.params[7] and
    spec.params[8]
    3. Added the parameters to the YAML example with sample values
    4. Added detailed parameter descriptions explaining:
      - How to use the Slack notification feature
      - How to disable it (leave SLACK_SECRET_NAME empty)
      - Example secret format
      - Default behavior