### PR TITLE
KFLUXSPRT-7415 - Expand fbc operator slack notif

### DIFF
--- a/pipelines/deploy-fbc-operator/0.1/README.MD
+++ b/pipelines/deploy-fbc-operator/0.1/README.MD
@@ -66,6 +66,8 @@ The pipeline consists of the following tasks:
 |PATH_TO_MIRROR_SET| Path to where the image digest mirror set is saved in the repository| ".tekton/images-mirror-set.yaml"| false|
 |SLACK_SECRET_NAME| Name of the secret containing the Slack webhook URL. Leave empty to disable Slack notifications| ""| false|
 |SLACK_KEY_NAME| Key name within the secret that contains the Slack webhook URL| "webhook_url"| false|
+|SLACK_MESSAGE| Custom message for Slack notifications. If empty, a default failure message will be used| ""| false|
+|KONFLUX_UI_URL| Base URL of the Konflux UI for constructing log links| "https://konflux-ui.apps.stone-prd-rh01.pg1f.p1.openshiftapps.com"| false|
 
 ## Pipeline Usage Guide
 
@@ -87,6 +89,8 @@ Open a merge request (MR) to your [tenants-config](https://gitlab.cee.redhat.com
 - `spec.params[6].value`  -> PATH_TO_MIRROR_SET (Optional)
 - `spec.params[7].value`  -> SLACK_SECRET_NAME (Optional)
 - `spec.params[8].value`  -> SLACK_KEY_NAME (Optional)
+- `spec.params[9].value`  -> SLACK_MESSAGE (Optional)
+- `spec.params[10].value` -> KONFLUX_UI_URL (Optional)
 
 ```yaml
 apiVersion: appstudio.redhat.com/v1beta2
@@ -120,6 +124,10 @@ spec:
       value: "slack-webhook-secret"
     - name: SLACK_KEY_NAME
       value: "webhook_url"
+    - name: SLACK_MESSAGE
+      value: "Production deployment "
+    - name: KONFLUX_UI_URL
+      value: "https://konflux-ui.apps.stone-prd-rh01.pg1f.p1.openshiftapps.com"
   resolverRef:
     params:
       - name: url
@@ -216,6 +224,25 @@ data:
 Key name within the secret that contains the Slack webhook URL. Defaults to `webhook_url`.
 
 This parameter specifies which key in the secret contains the actual Slack webhook URL. In the example above, the `SLACK_KEY_NAME` value should be `webhook_url`.
+
+#### SLACK_MESSAGE (Optional)
+
+Custom message for Slack notifications. If empty, a default failure message will be used.
+
+This parameter allows you to add a custom message prefix to the Slack notification. The message will be displayed before the default "PipelineRun failed" text.
+
+Example: If you set `SLACK_MESSAGE` to "Production deployment ", the notification will read:
+```
+❌ Production deployment PipelineRun <name> failed
+```
+
+#### KONFLUX_UI_URL (Optional)
+
+Base URL of the Konflux UI for constructing log links. Defaults to `https://konflux-ui.apps.stone-prd-rh01.pg1f.p1.openshiftapps.com`.
+
+This parameter is used to construct a direct link to the pipeline run logs in the Konflux UI. The notification will include a "View logs" link that directs users to the full pipeline run details.
+
+If your Konflux instance is hosted at a different URL, update this parameter accordingly.
 
 ### What Happens Next
 

--- a/pipelines/deploy-fbc-operator/0.1/deploy-fbc-operator.yaml
+++ b/pipelines/deploy-fbc-operator/0.1/deploy-fbc-operator.yaml
@@ -77,6 +77,17 @@ spec:
       name: SLACK_KEY_NAME
       default: "webhook_url"
       type: string
+    - description: |
+        Custom message for Slack notifications. If empty, a default failure message will be used.
+      name: SLACK_MESSAGE
+      default: ""
+      type: string
+    - description: |
+        Base URL of the Konflux UI for constructing log links.
+        Example: https://konflux-ui.apps.stone-prd-rh01.pg1f.p1.openshiftapps.com
+      name: KONFLUX_UI_URL
+      default: "https://konflux-ui.apps.stone-prd-rh01.pg1f.p1.openshiftapps.com"
+      type: string
   tasks:
     - name: parse-metadata
       taskRef:
@@ -933,7 +944,10 @@ spec:
     - name: slack-webhook-notification
       params:
         - name: message
-          value: PipelineRun $(context.pipelineRun.name) failed
+          value: |
+            ❌ $(params.SLACK_MESSAGE)PipelineRun $(context.pipelineRun.name) failed
+
+            View logs: $(params.KONFLUX_UI_URL)/ns/$(context.pipelineRun.namespace)/applications/$(tasks.parse-metadata.results.application-name)/pipelineruns/$(context.pipelineRun.name)
         - name: secret-name
           value: $(params.SLACK_SECRET_NAME)
         - name: key-name

--- a/pipelines/deploy-fbc-operator/0.2/README.MD
+++ b/pipelines/deploy-fbc-operator/0.2/README.MD
@@ -82,6 +82,8 @@ The pipeline consists of the following tasks:
 |PATH_TO_MIRROR_SET| Path to where the image digest mirror set is saved in the repository| ".tekton/images-mirror-set.yaml"| false|
 |SLACK_SECRET_NAME| Name of the secret containing the Slack webhook URL. Leave empty to disable Slack notifications| ""| false|
 |SLACK_KEY_NAME| Key name within the secret that contains the Slack webhook URL| "webhook_url"| false|
+|SLACK_MESSAGE| Custom message for Slack notifications. If empty, a default failure message will be used| ""| false|
+|KONFLUX_UI_URL| Base URL of the Konflux UI for constructing log links| "https://konflux-ui.apps.stone-prd-rh01.pg1f.p1.openshiftapps.com"| false|
 
 ## Pipeline Usage Guide
 
@@ -103,6 +105,8 @@ Open a merge request (MR) to your [tenants-config](https://gitlab.cee.redhat.com
 - `spec.params[6].value`  -> PATH_TO_MIRROR_SET (Optional)
 - `spec.params[7].value`  -> SLACK_SECRET_NAME (Optional)
 - `spec.params[8].value`  -> SLACK_KEY_NAME (Optional)
+- `spec.params[9].value`  -> SLACK_MESSAGE (Optional)
+- `spec.params[10].value` -> KONFLUX_UI_URL (Optional)
 
 ```yaml
 apiVersion: appstudio.redhat.com/v1beta2
@@ -136,6 +140,10 @@ spec:
       value: "slack-webhook-secret"
     - name: SLACK_KEY_NAME
       value: "webhook_url"
+    - name: SLACK_MESSAGE
+      value: "Production deployment "
+    - name: KONFLUX_UI_URL
+      value: "https://konflux-ui.apps.stone-prd-rh01.pg1f.p1.openshiftapps.com"
   resolverRef:
     resourceKind: pipelinerun
     params:
@@ -233,6 +241,25 @@ data:
 Key name within the secret that contains the Slack webhook URL. Defaults to `webhook_url`.
 
 This parameter specifies which key in the secret contains the actual Slack webhook URL. In the example above, the `SLACK_KEY_NAME` value should be `webhook_url`.
+
+#### SLACK_MESSAGE (Optional)
+
+Custom message for Slack notifications. If empty, a default failure message will be used.
+
+This parameter allows you to add a custom message prefix to the Slack notification. The message will be displayed before the default "PipelineRun failed" text.
+
+Example: If you set `SLACK_MESSAGE` to "Production deployment ", the notification will read:
+```
+❌ Production deployment PipelineRun <name> failed
+```
+
+#### KONFLUX_UI_URL (Optional)
+
+Base URL of the Konflux UI for constructing log links. Defaults to `https://konflux-ui.apps.stone-prd-rh01.pg1f.p1.openshiftapps.com`.
+
+This parameter is used to construct a direct link to the pipeline run logs in the Konflux UI. The notification will include a "View logs" link that directs users to the full pipeline run details.
+
+If your Konflux instance is hosted at a different URL, update this parameter accordingly.
 
 ### What Happens Next
 

--- a/pipelines/deploy-fbc-operator/0.2/deploy-fbc-operator.yaml
+++ b/pipelines/deploy-fbc-operator/0.2/deploy-fbc-operator.yaml
@@ -77,6 +77,17 @@ spec:
       name: SLACK_KEY_NAME
       default: "webhook_url"
       type: string
+    - description: |
+        Custom message for Slack notifications. If empty, a default failure message will be used.
+      name: SLACK_MESSAGE
+      default: ""
+      type: string
+    - description: |
+        Base URL of the Konflux UI for constructing log links.
+        Example: https://konflux-ui.apps.stone-prd-rh01.pg1f.p1.openshiftapps.com
+      name: KONFLUX_UI_URL
+      default: "https://konflux-ui.apps.stone-prd-rh01.pg1f.p1.openshiftapps.com"
+      type: string
   workspaces:
     - name: shared-data
   tasks:
@@ -936,7 +947,10 @@ spec:
     - name: slack-webhook-notification
       params:
         - name: message
-          value: PipelineRun $(context.pipelineRun.name) failed
+          value: |
+            ❌ $(params.SLACK_MESSAGE)PipelineRun $(context.pipelineRun.name) failed
+
+            View logs: $(params.KONFLUX_UI_URL)/ns/$(context.pipelineRun.namespace)/applications/$(tasks.parse-metadata.results.application-name)/pipelineruns/$(context.pipelineRun.name)
         - name: secret-name
           value: $(params.SLACK_SECRET_NAME)
         - name: key-name


### PR DESCRIPTION
1. Pipeline YAML Files (both 0.1 and 0.2)

  - Added 3 new parameters:
    - SLACK_MESSAGE: Custom message prefix for notifications
    - KONFLUX_UI_URL: Base URL for Konflux UI (defaults to your
  production URL)
    - APPLICATION_NAME: Required for constructing log links
  - Updated the slack notification message to include:
    - ❌ emoji
    - Custom message from the parameter
    - Clickable log link using the format: {KONFLUX_UI_URL}/ns/{namespace
  }/applications/{APPLICATION_NAME}/pipelineruns/{pipelineRunName}

  2. README Files (both 0.1 and 0.2)

  - Added the new parameters to the parameters table
  - Added detailed descriptions for each parameter explaining:
    - What they do
    - How to use them
    - Example values
    - The log link format
  - Updated the IntegrationTestScenario example to show all new
  parameters with sample values