### PR TITLE
Update deploy-konflux-ci.yaml to use the legacy branch

### DIFF
--- a/tasks/konflux-ci/deploy/0.3/deploy-konflux-ci.yaml
+++ b/tasks/konflux-ci/deploy/0.3/deploy-konflux-ci.yaml
@@ -24,7 +24,7 @@ spec:
       default: https://github.com/konflux-ci/konflux-ci.git
     - name: repo-branch
       description: Git branch to check out when cloning the repository.
-      default: main
+      default: legacy
     - name: create-test-resources
       description: 'Indicates if a set of test resources should be installed'
       default: 'true'


### PR DESCRIPTION
We need to deprecate the legacy installation flow from konflux-ci, but the new task with the operator installation flow isn't ready yet. A temporary solution would be to use a branch where the legacy flow is still supported.