### PR TITLE
feat: add rosa-hcp-provision/deprovision 0.3 and secure-push-oci 0.2

### DIFF
--- a/stepactions/secure-push-oci/0.2/README.md
+++ b/stepactions/secure-push-oci/0.2/README.md
@@ -1,0 +1,24 @@
+# secure-push-oci stepaction
+
+This StepAction scans specified directory (workingDir) using [leaktk-scanner CLI](https://github.com/leaktk/scanner)
+and deletes files containing sensitive information (credentials, certificates) that shouldn't be exposed to public.
+Then it pushes the working directory contents to a specified OCI artifact repository tag.
+If the tag exists, it will update the existing content with the content of the working directory.
+
+## Changes from 0.1
+
+The secret key used for registry credentials is now configurable via `credentials-volume-key` (default: `oci-storage-dockerconfigjson`).
+This allows standard Kubernetes image pull secrets to be used directly without requiring a custom key name.
+
+## Parameters
+
+|name|description|default value|required|
+|---|---|---|---|
+|workdir-path|Path to the workdir that is about to be uploaded to OCI artifact||true|
+|credentials-volume-name|Name of the volume that mounts the Kubernetes secret containing registry credentials||true|
+|credentials-volume-key|Key within the secret that holds the registry credentials in .dockerconfigjson format|`oci-storage-dockerconfigjson`|false|
+|oci-ref|Full OCI artifact reference in a format "quay.io/org/repo:tag"||true|
+|oci-tag-expiration|OCI artifact tag expiration|1y|false|
+|always-pass|Even if execution of the stepaction's script fails, do not fail the step|"true"|false|
+
+### Suitable for upstream communities

--- a/stepactions/secure-push-oci/0.2/secure-push-oci.yaml
+++ b/stepactions/secure-push-oci/0.2/secure-push-oci.yaml
@@ -1,0 +1,101 @@
+apiVersion: tekton.dev/v1alpha1
+kind: StepAction
+metadata:
+  name: secure-push-oci
+  labels:
+    upstream-usable: "true"
+spec:
+  description: |
+    This StepAction scans specified directory (workingDir) using [leaktk-scanner CLI](https://github.com/leaktk/scanner)
+    and deletes files containing sensitive information (credentials, certificates) that shouldn't be exposed to public.
+    Then it pushes the working directory contents to a specified OCI artifact repository tag.
+    If the tag exists, it will update the existing content with the content of the working directory.
+  image: quay.io/konflux-qe-incubator/konflux-qe-tools:latest
+  params:
+    - name: workdir-path
+      type: string
+      description: Path to the workdir that is about to be uploaded to OCI artifact
+    - name: oci-ref
+      type: string
+      description: Full OCI artifact reference in a format "quay.io/org/repo:tag"
+    - name: credentials-volume-name
+      type: string
+      description: Name of the volume that mounts the Kubernetes secret containing registry credentials
+    - name: credentials-volume-key
+      type: string
+      default: oci-storage-dockerconfigjson
+      description: Key within the secret that holds the registry credentials in .dockerconfigjson format
+    - name: oci-tag-expiration
+      type: string
+      default: 1y
+      description: OCI artifact tag expiration
+    - name: always-pass
+      type: string
+      default: "true"
+      description: Even if execution of the stepaction's script fails, do not fail the step
+  volumeMounts:
+  - name: $(params.credentials-volume-name)
+    mountPath: /home/tool-box/.docker/config.json
+    subPath: $(params.credentials-volume-key)
+  workingDir: $(params.workdir-path)
+  env:
+    - name: OCI_ARTIFACT_REFERENCE
+      value: "$(params.oci-ref)"
+    - name: OCI_TAG_EXPIRATION
+      value: "$(params.oci-tag-expiration)"
+    - name: ALWAYS_PASS
+      value: "$(params.always-pass)"
+  script: |
+    #!/bin/bash
+    set -e
+
+    main() {
+      IMAGE_REF_REGEX='^quay\.io/[a-zA-Z0-9_-]+(/[a-zA-Z0-9_-]+)+:[a-zA-Z0-9._-]+$'
+
+      if [[ ! $OCI_ARTIFACT_REFERENCE =~ $IMAGE_REF_REGEX ]]; then
+          echo -e "[ERROR]: provided OCI artifact reference '$OCI_ARTIFACT_REFERENCE' is not in correct format 'quay.io/org/repo:tag'"
+          exit 1
+      fi
+
+      TAG="${OCI_ARTIFACT_REFERENCE##*:}"
+
+      TEMP_ANNOTATION_FILE="$(mktemp)"
+
+      # Fetch the manifest annotations for the container
+      MANIFESTS_ANNOTATIONS=$(oras manifest fetch "$OCI_ARTIFACT_REFERENCE" 2>> /dev/null | jq .annotations) || true
+
+      if [ "$MANIFESTS_ANNOTATIONS" == "" ]; then
+          # Create the annotations file, because it does not exist in the OCI artifact
+          echo -e "[INFO]: provided OCI artifact tag '$OCI_ARTIFACT_REFERENCE' does not exist - will create it"
+          jq -n --arg exp "$OCI_TAG_EXPIRATION" --arg title "Artifact storage for pipelinerun: $TAG" \
+              '{"$manifest": {"quay.expires-after": $exp, "org.opencontainers.image.title": $title}}' > "${TEMP_ANNOTATION_FILE}"
+      else
+          echo -e "[INFO]: going to update existing content in '$OCI_ARTIFACT_REFERENCE'"
+          # Keep the existing annotations file for further use
+          jq -n --argjson manifest "$MANIFESTS_ANNOTATIONS" '{ "$manifest": $manifest }' > "${TEMP_ANNOTATION_FILE}"
+          oras pull "$OCI_ARTIFACT_REFERENCE"
+      fi
+
+      # Scan the working directory using leaktk-scanner and remove problematic files
+      log_filename="leaktk-scan-$(date +%s).log"
+      leaktk-scanner scan --kind Files --resource . 2>> $log_filename | leaktk-remove-files . &>> $log_filename
+
+      # Push the content to remote artifact storage
+      attempt=1
+      while ! oras push "$OCI_ARTIFACT_REFERENCE" --annotation-file "${TEMP_ANNOTATION_FILE}" ./:application/vnd.acme.rocket.docs.layer.v1+tar; do
+          if [[ $attempt -ge 5 ]]; then
+              echo -e "[ERROR]: oras push failed after $attempt attempts."
+              rm -f "${TEMP_ANNOTATION_FILE}"
+              exit 1
+          fi
+          echo -e "[WARNING]: oras push failed (attempt $attempt). Retrying in 5 seconds..."
+          sleep 5
+          ((attempt++))
+      done
+    }
+
+    if [ "$ALWAYS_PASS" == "true" ]; then
+      main || true
+    else
+      main
+    fi

--- a/tasks/rosa/hosted-cp/rosa-hcp-deprovision/0.3/README.md
+++ b/tasks/rosa/hosted-cp/rosa-hcp-deprovision/0.3/README.md
@@ -1,0 +1,130 @@
+# Deprovision ROSA - Tekton Task
+
+**Version:** 0.3
+
+## Overview
+
+This Tekton Task handles the collection of test artifacts and the deprovisioning of an OpenShift ROSA HCP cluster. It automates the following steps:
+
+1. **Collect Artifacts**: Gathers test artifacts if the pipeline did not succeed.
+2. **Inspect and Upload Artifacts**: Checks for sensitive information and uploads artifacts to an OCI container registry.
+3. **Deprovision ROSA Cluster**: Deletes the OpenShift ROSA HCP cluster and, once deletion completes, removes the managed OIDC config that was created during provisioning.
+4. **Remove Tags from Subnets**: Cleans up AWS subnet tags associated with the cluster.
+
+## Changes from 0.2
+
+The `deprovision-rosa` step now cleans up all per-cluster AWS resources created by `rosa-hcp-provision` 0.3. When `oidc-config-id` is provided, after the cluster deletion completes it:
+
+1. Deletes the per-cluster operator roles (`rosa delete operator-roles --prefix <cluster-name>`).
+2. Deletes the per-cluster managed OIDC config (`rosa delete oidc-config`).
+
+This ensures each provisioning run starts with a clean slate and avoids OIDC provider or operator role conflicts.
+
+The `remove-load-balancers` step has been removed. Load balancers are cleaned up automatically as part of cluster deletion.
+
+## Parameters
+
+| Name | Type | Description | Default |
+|------|------|-------------|---------|
+| `test-name` | string | The name of the test being executed. | - |
+| `ocp-login-command` | string | Command to log in to the OpenShift cluster. | - |
+| `oci-container` | string | ORAS container registry URI where artifacts will be stored. | - |
+| `cluster-name` | string | The name of the OpenShift cluster to be deleted. | - |
+| `oidc-config-id` | string | ID of the managed OIDC config created during provisioning. Pass the `oidc-config-id` result from `rosa-hcp-provision`. | `""` |
+| `konflux-test-infra-secret` | string | Secret containing credentials for testing infrastructure. | - |
+| `cloud-credential-key` | string | Key within the secret that stores AWS ROSA configuration details. | - |
+| `oci-credentials-secret` | string | Secret containing OCI registry credentials. | - |
+| `oci-credentials-secret-key` | string | Key within the OCI credentials secret that holds the registry credentials in `.dockerconfigjson` format. | `.dockerconfigjson` |
+| `pipeline-aggregate-status` | string | The status of the pipeline (e.g., `Succeeded`, `Failed`). | `None` |
+
+## Volumes
+
+- `konflux-test-infra-volume`: Mounts the `konflux-test-infra-secret` to access AWS/ROSA credentials.
+- `oci-credentials-volume`: Mounts the `oci-credentials-secret` to access OCI registry credentials. The key within the secret is controlled by `oci-credentials-secret-key`.
+
+## Steps
+
+### 1. Collect Artifacts
+
+- Logs into the OpenShift cluster.
+- If the pipeline failed, gathers additional artifacts using `gather-extra.sh`.
+
+### 2. Inspect and Upload Artifacts
+
+- Scans artifacts for sensitive data and removes detected files.
+- Authenticates to the OCI container registry.
+- Pushes the artifacts with manifest annotations.
+- Runs with `onError: continue` so that upload failures never block cluster deprovisioning.
+
+### 3. Deprovision ROSA Cluster
+
+- Reads AWS credentials and ROSA token from the secret.
+- Logs into AWS and ROSA CLI.
+- Initiates cluster deletion (`rosa delete cluster`). Failures are non-fatal and logged as warnings.
+- If `oidc-config-id` is provided, waits for the cluster to finish uninstalling, then:
+  - Deletes the per-cluster operator roles (`rosa delete operator-roles --prefix <cluster-name>`).
+  - Deletes the per-cluster managed OIDC config (`rosa delete oidc-config`).
+  - Each cleanup command is failure-tolerant: errors are logged as warnings and do not abort the step.
+
+### 4. Remove Tags from Subnets
+
+- Retrieves AWS subnet IDs related to the cluster.
+- If the cluster no longer exists in ROSA (e.g. already deleted), subnet tag removal is skipped gracefully.
+- Removes Kubernetes tags from the associated AWS subnets. Failures are non-fatal and logged as warnings.
+
+## Usage
+
+```yaml
+- name: deprovision-rosa-collect-artifacts
+  when:
+    - input: "$(tasks.test-metadata.results.test-event-type)"
+      operator: in
+      values: ["pull_request"]
+  taskRef:
+    resolver: git
+    params:
+      - name: url
+        value: https://github.com/konflux-ci/tekton-integration-catalog.git
+      - name: revision
+        value: main
+      - name: pathInRepo
+        value: tasks/rosa/hosted-cp/rosa-hcp-deprovision/0.3/rosa-hcp-deprovision.yaml
+  params:
+    - name: test-name
+      value: "$(context.pipelineRun.name)"
+    - name: ocp-login-command
+      value: "$(tasks.provision-rosa.results.ocp-login-command)"
+    - name: oidc-config-id
+      value: "$(tasks.provision-rosa.results.oidc-config-id)"
+    - name: oci-container
+      value: "$(params.oci-container-repo):$(context.pipelineRun.name)"
+    - name: cluster-name
+      value: "$(tasks.rosa-hcp-metadata.results.cluster-name)"
+    - name: konflux-test-infra-secret
+      value: "$(params.konflux-test-infra-secret)"
+    - name: cloud-credential-key
+      value: "$(params.cloud-credential-key)"
+    - name: oci-credentials-secret
+      value: "$(params.oci-credentials-secret)"
+    - name: oci-credentials-secret-key
+      value: "$(params.oci-credentials-secret-key)"
+    - name: pipeline-aggregate-status
+      value: "$(tasks.status)"
+```
+
+## Requirements
+
+- OpenShift CLI (`oc`)
+- AWS CLI (`aws`)
+- ROSA CLI (`rosa`)
+- ORAS CLI (`oras`)
+- jq (for JSON parsing)
+
+## Notes
+
+- Ensure that the secret referenced by `konflux-test-infra-secret` contains the necessary AWS credentials and ROSA tokens.
+- The `oci-credentials-secret` must contain a key matching `oci-credentials-secret-key` (default: `.dockerconfigjson`) with a valid `.dockerconfigjson`-format value that has push access to the target registry.
+- `oidc-config-id` must be the result from `rosa-hcp-provision` 0.3. When using older provision versions that used a static OIDC config, leave this parameter empty and no operator roles or OIDC config cleanup will occur.
+- Operator role and OIDC config deletion waits for the cluster to fully uninstall first. Both resources cannot be removed while the cluster is still active.
+
+### Not suitable for upstream communities

--- a/tasks/rosa/hosted-cp/rosa-hcp-deprovision/0.3/rosa-hcp-deprovision.yaml
+++ b/tasks/rosa/hosted-cp/rosa-hcp-deprovision/0.3/rosa-hcp-deprovision.yaml
@@ -1,0 +1,204 @@
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: collect-artifacts-deprovision-rosa
+  labels:
+    app.kubernetes.io/version: "0.3"
+    upstream-usable: "false"
+  annotations:
+    tekton.dev/pipelines.minVersion: 0.12.1
+    tekton.dev/tags: konflux
+spec:
+  description: |
+    This Tekton Task handles the collection of test artifacts and deprovisions the OpenShift cluster. The task performs the following steps:
+    1. **Collect Artifacts**: Gathers artifacts if the pipeline did not succeed.
+    2. **Inspect and Upload Artifacts**: Checks for sensitive information in the artifacts and uploads them to the OCI container registry.
+    3. **Deprovision ROSA Cluster**: Deletes the OpenShift cluster if specified.
+    4. **Delete OIDC Config**: Removes the managed OIDC config created during provisioning.
+    5. **Remove Tags from Subnets**: Cleans up tags from AWS subnets associated with the cluster.
+  params:
+    - name: test-name
+      type: string
+      description: The name of the test being executed.
+    - name: ocp-login-command
+      type: string
+      description: Command to log in to the OpenShift cluster.
+    - name: oci-container
+      type: string
+      description: The ORAS container registry URI where artifacts will be stored.
+    - name: cluster-name
+      type: string
+      description: The name of the OpenShift cluster that is to be deleted.
+    - name: oidc-config-id
+      type: string
+      description: The ID of the managed OIDC config created during provisioning to be deleted.
+      default: ""
+    - name: konflux-test-infra-secret
+      type: string
+      description: The name of the secret containing credentials for testing infrastructure.
+    - name: cloud-credential-key
+      type: string
+      description: The key within the konflux-test-infra secret where AWS ROSA configuration details are stored.
+    - name: oci-credentials-secret
+      type: string
+      description: Name of the Kubernetes Secret containing OCI registry credentials for pushing artifacts.
+    - name: oci-credentials-secret-key
+      type: string
+      default: .dockerconfigjson
+      description: Key within the OCI credentials secret that holds the registry credentials in .dockerconfigjson format.
+    - name: pipeline-aggregate-status
+      type: string
+      description: The status of the pipeline (e.g., Succeeded, Failed, Completed, None).
+      default: None
+  volumes:
+    - name: konflux-test-infra-volume
+      secret:
+        secretName: "$(params.konflux-test-infra-secret)"
+    - name: oci-credentials-volume
+      secret:
+        secretName: "$(params.oci-credentials-secret)"
+  steps:
+    - name: collect-artifacts
+      workingDir: /workspace/cluster-artifacts
+      onError: continue
+      image: quay.io/konflux-qe-incubator/konflux-qe-tools:latest
+      script: |
+        #!/bin/sh
+        $(params.ocp-login-command)
+
+        curl -sSL https://raw.githubusercontent.com/konflux-ci/konflux-qe-definitions/main/scripts/gather-extra.sh | bash
+      when:
+        - input: $(params.pipeline-aggregate-status)
+          operator: notin
+          values: ["Succeeded"]
+    - name: secure-push-oci
+      onError: continue
+      ref:
+        resolver: git
+        params:
+          - name: url
+            value: https://github.com/PabloHiro/tekton-integration-catalog.git
+          - name: revision
+            value: feature/rosa-hcp-provision-separate-oci-secret
+          - name: pathInRepo
+            value: stepactions/secure-push-oci/0.2/secure-push-oci.yaml
+      params:
+        - name: workdir-path
+          value: /workspace
+        - name: oci-ref
+          value: $(params.oci-container)
+        - name: credentials-volume-name
+          value: oci-credentials-volume
+        - name: credentials-volume-key
+          value: $(params.oci-credentials-secret-key)
+      when:
+        - input: $(params.pipeline-aggregate-status)
+          operator: notin
+          values: ["Succeeded"]
+    - name: deprovision-rosa
+      image: quay.io/konflux-qe-incubator/konflux-qe-tools:latest
+      onError: continue
+      volumeMounts:
+        - name: konflux-test-infra-volume
+          mountPath: /usr/local/konflux-test-infra
+      script: |
+        #!/bin/bash
+        set -euo pipefail
+
+        export CLUSTER_NAME REGION AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY ROSA_TOKEN OIDC_CONFIG_ID OPERATOR_ROLES_PREFIX
+
+        CLUSTER_NAME=$(params.cluster-name)
+        OIDC_CONFIG_ID=$(params.oidc-config-id)
+        OPERATOR_ROLES_PREFIX="$CLUSTER_NAME"
+        REGION=$(jq -r '.aws["region"]' /usr/local/konflux-test-infra/$(params.cloud-credential-key))
+        AWS_ACCESS_KEY_ID=$(jq -r '.aws["access-key-id"]' /usr/local/konflux-test-infra/$(params.cloud-credential-key))
+        AWS_SECRET_ACCESS_KEY=$(jq -r '.aws["access-key-secret"]' /usr/local/konflux-test-infra/$(params.cloud-credential-key))
+        ROSA_TOKEN=$(jq -r '.aws["rosa-hcp"]["rosa-token"]' /usr/local/konflux-test-infra/$(params.cloud-credential-key))
+
+        try() {
+            local rc
+            "$@" && rc=0 || rc=$?
+            if [[ $rc -ne 0 ]]; then
+                printf "WARN: Command failed (exit %d): %s\n" "$rc" "$*" >&2
+            fi
+            return 0
+        }
+
+        config_aws_creds() {
+            aws configure set aws_access_key_id "$AWS_ACCESS_KEY_ID"
+            aws configure set aws_secret_access_key "$AWS_SECRET_ACCESS_KEY"
+            aws configure set region "$REGION"
+        }
+
+        echo "INFO: [$(date +"%Y/%m/%d %H:%M:%S")] Started to destroy cluster [$CLUSTER_NAME]..."
+
+        printf "INFO: Logging in to your Red Hat account...\n"
+        config_aws_creds
+        rosa login --token="$ROSA_TOKEN"
+
+        try rosa delete cluster --region "$REGION" --cluster="$CLUSTER_NAME" -y
+
+        if [[ -n "$OIDC_CONFIG_ID" ]]; then
+            printf "INFO: Waiting for cluster deletion before removing operator roles and OIDC config...\n"
+            try rosa logs uninstall --cluster="$CLUSTER_NAME" --region "$REGION" --watch
+
+            printf "INFO: Deleting operator roles with prefix [%s]...\n" "$OPERATOR_ROLES_PREFIX"
+            try rosa delete operator-roles --prefix "$OPERATOR_ROLES_PREFIX" --region "$REGION" --mode=auto -y
+
+            printf "INFO: Deleting OIDC provider [%s]...\n" "$OIDC_CONFIG_ID"
+            try rosa delete oidc-provider --oidc-config-id "$OIDC_CONFIG_ID" --region "$REGION" --mode=auto -y
+
+            printf "INFO: Deleting managed OIDC config [%s]...\n" "$OIDC_CONFIG_ID"
+            try rosa delete oidc-config --oidc-config-id "$OIDC_CONFIG_ID" --region "$REGION" --mode=auto -y
+        else
+            printf "WARN: OIDC_CONFIG_ID not set, skipping operator roles and OIDC config deletion.\n"
+        fi
+
+        echo "INFO: [$(date +"%Y/%m/%d %H:%M:%S")] Done"
+    - name: remove-tag-from-subnets
+      image: quay.io/konflux-qe-incubator/konflux-qe-tools:latest
+      onError: continue
+      volumeMounts:
+        - name: konflux-test-infra-volume
+          mountPath: /usr/local/konflux-test-infra
+      script: |
+        #!/bin/bash
+        set -euo pipefail
+
+        try() {
+            local rc
+            "$@" && rc=0 || rc=$?
+            if [[ $rc -ne 0 ]]; then
+                printf "WARN: Command failed (exit %d): %s\n" "$rc" "$*" >&2
+            fi
+            return 0
+        }
+
+        CLUSTER_NAME=$(params.cluster-name)
+        REGION=$(jq -r '.aws["region"]' /usr/local/konflux-test-infra/$(params.cloud-credential-key))
+        AWS_ACCESS_KEY_ID=$(jq -r '.aws["access-key-id"]' /usr/local/konflux-test-infra/$(params.cloud-credential-key))
+        AWS_SECRET_ACCESS_KEY=$(jq -r '.aws["access-key-secret"]' /usr/local/konflux-test-infra/$(params.cloud-credential-key))
+        ROSA_TOKEN=$(jq -r '.aws["rosa-hcp"]["rosa-token"]' /usr/local/konflux-test-infra/$(params.cloud-credential-key))
+        SUBNET_IDS=$(jq -r '.aws["rosa-hcp"]["subnets-ids"]' /usr/local/konflux-test-infra/$(params.cloud-credential-key))
+
+        aws configure set aws_access_key_id "$AWS_ACCESS_KEY_ID"
+        aws configure set aws_secret_access_key "$AWS_SECRET_ACCESS_KEY"
+        aws configure set region "$REGION"
+
+        echo "INFO: [$(date +"%Y/%m/%d %H:%M:%S")] Started to remove tags of cluster [$CLUSTER_NAME]..."
+
+        printf "INFO: Logging in to your Red Hat account...\n"
+        rosa login --token="$ROSA_TOKEN"
+
+        cluster_id=$(rosa --region "$REGION" describe cluster --cluster="$CLUSTER_NAME" -o json 2>/dev/null | jq -r .id)
+        if [[ -z "$cluster_id" || "$cluster_id" == "null" ]]; then
+            printf "WARN: Could not find cluster ID for [%s], skipping subnet tag removal.\n" "$CLUSTER_NAME"
+            exit 0
+        fi
+        echo "INFO: Cluster ID: $cluster_id"
+
+        echo "INFO: Removing tag from subnets [$SUBNET_IDS]..."
+        read -ra subnet_array <<< "${SUBNET_IDS//,/ }"
+        try aws --region "$REGION" ec2 delete-tags --resources "${subnet_array[@]}" --tags Key="kubernetes.io/cluster/${cluster_id}"
+
+        echo "INFO: [$(date +"%Y/%m/%d %H:%M:%S")] Done"

--- a/tasks/rosa/hosted-cp/rosa-hcp-provision/0.3/README.md
+++ b/tasks/rosa/hosted-cp/rosa-hcp-provision/0.3/README.md
@@ -1,0 +1,123 @@
+# ROSA HCP Provision
+
+**Version:** 0.3
+
+## Overview
+
+This Tekton Task automates the provisioning of an ephemeral OpenShift cluster using Red Hat OpenShift on AWS (ROSA) with Hosted Control Planes (HCP). It handles the following:
+
+1. **Fetch and Configure AWS & ROSA Credentials**: Reads credentials from a Openshift secret.
+2. **Provision OpenShift Cluster**: Deploys a ROSA HCP cluster with the specified configuration.
+3. **Generate Cluster Login Credentials**: Outputs the `oc login` command to access the cluster.
+4. **Validate Cluster Readiness**: Ensures all required cluster operators are operational.
+5. **Push Logs to OCI Container**: Secures and stores provisioning logs in an OCI artifact registry.
+
+## Changes from 0.2
+
+- OCI registry credentials are now passed via a **dedicated secret** (`oci-credentials-secret`) instead of being bundled into the infrastructure secret (`konflux-test-infra-secret`). This keeps AWS/ROSA credentials and OCI push credentials separate.
+- Each cluster run now gets fully isolated per-cluster AWS resources to avoid conflicts when provisioning against the same account and region:
+  - A managed OIDC config is created dynamically (instead of using a static `aws-oidc-config-id`), giving each cluster a unique OIDC provider URL in IAM.
+  - Operator roles are created per cluster using `cluster-name` as the prefix (instead of a static prefix), with their trust policy tied to the per-cluster OIDC config.
+  - Account roles (Installer, Support, Worker) remain shared and are auto-discovered by the ROSA CLI via IAM tags.
+- The static `operator-roles-prefix`, `aws-oidc-config-id`, `install-role-arn`, `support-role-arn`, and `worker-role-arn` keys are no longer read from the secret.
+- The `oidc-config-id` result must be passed to `rosa-hcp-deprovision` 0.3 for cleanup.
+
+## Parameters
+
+| Name | Type | Description | Default |
+|------|------|-------------|---------|
+| `ocp-version` | string | The OpenShift Container Platform (OCP) version to deploy. | - |
+| `cluster-name` | string | Unique name for the OpenShift cluster. | - |
+| `machine-type` | string | AWS EC2 instance type for worker nodes (e.g., `m5.xlarge`). | - |
+| `replicas` | string | Number of worker nodes in the cluster. | `3` |
+| `konflux-test-infra-secret` | string | Secret containing AWS and ROSA credentials. | - |
+| `cloud-credential-key` | string | Key within the secret storing AWS ROSA configurations. | - |
+| `oci-container` | string | ORAS container registry URI to store provisioning logs. | - |
+| `oci-credentials-secret` | string | Secret containing OCI registry credentials. | - |
+| `oci-credentials-secret-key` | string | Key within the OCI credentials secret that holds the registry credentials in `.dockerconfigjson` format. | `.dockerconfigjson` |
+| `tags` | string | Optional tags to apply to the cluster in `key:value` format, comma-separated (e.g. `env:staging,team:qe`). When empty, no tags are applied. | `''` |
+
+## Results
+
+| Name | Description |
+|------|-------------|
+| `ocp-login-command` | Command to log in to the newly provisioned OpenShift cluster. |
+| `oidc-config-id` | ID of the managed OIDC config created for this cluster. Pass this to `rosa-hcp-deprovision` for cleanup. |
+
+## Volumes
+
+- `konflux-test-infra-volume`: Mounts the `konflux-test-infra-secret` to access AWS/ROSA credentials.
+- `oci-credentials-volume`: Mounts the `oci-credentials-secret` to access OCI registry credentials. The key within the secret is controlled by `oci-credentials-secret-key`.
+
+## Usage
+
+```yaml
+- name: provision-rosa-hcp
+  taskRef:
+    resolver: git
+    params:
+      - name: url
+        value: https://github.com/konflux-ci/tekton-integration-catalog.git
+      - name: revision
+        value: main
+      - name: pathInRepo
+        value: tasks/rosa/hosted-cp/rosa-hcp-provision/0.3/rosa-hcp-provision.yaml
+  params:
+    - name: ocp-version
+      value: "4.18"
+    - name: cluster-name
+      value: "test-cluster-123"
+    - name: machine-type
+      value: "m5.xlarge"
+    - name: replicas
+      value: "3"
+    - name: konflux-test-infra-secret
+      value: "aws-rosa-secret"
+    - name: cloud-credential-key
+      value: "credentials.json"
+    - name: oci-container
+      value: "quay.io/example/rosa-logs:latest"
+    - name: oci-credentials-secret
+      value: "my-quay-push-secret"
+    - name: oci-credentials-secret-key
+      value: ".dockerconfigjson"
+```
+
+The `oci-credentials-secret` must contain a key matching `oci-credentials-secret-key` (default: `.dockerconfigjson`) with a valid `.dockerconfigjson`-format value that has push access to the target registry.
+
+## Requirements
+
+- OpenShift CLI (`oc`)
+- AWS CLI (`aws`)
+- ROSA CLI (`rosa`)
+- ORAS CLI (`oras`)
+- jq (for JSON parsing)
+
+## Secret structure
+
+The `konflux-test-infra-secret` credential file must contain:
+
+```json
+{
+  "aws": {
+    "access-key-id": "...",
+    "access-key-secret": "...",
+    "aws-account-id": "...",
+    "region": "...",
+    "rosa-hcp": {
+      "rosa-token": "...",
+      "subnets-ids": "subnet-abc,subnet-def"
+    }
+  }
+}
+```
+
+The following keys that were required in older versions are no longer needed: `aws-oidc-config-id`, `operator-roles-prefix`, `install-role-arn`, `support-role-arn`, `worker-role-arn`.
+
+## Notes
+
+- Account roles (Installer, Support, Worker) must exist in the AWS account and be tagged for ROSA discovery (i.e. created via `rosa create account-roles`). They are auto-discovered by the ROSA CLI and do not need to be specified explicitly.
+- Cluster provisioning may take several minutes depending on AWS region and workload.
+- Artifacts and logs are securely stored in the provided OCI container registry.
+
+### Not suitable for upstream communities

--- a/tasks/rosa/hosted-cp/rosa-hcp-provision/0.3/rosa-hcp-provision.yaml
+++ b/tasks/rosa/hosted-cp/rosa-hcp-provision/0.3/rosa-hcp-provision.yaml
@@ -1,0 +1,274 @@
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: rosa-hcp-provision
+  labels:
+    app.kubernetes.io/version: "0.3"
+    upstream-usable: "false"
+  annotations:
+    tekton.dev/pipelines.minVersion: 0.12.1
+    tekton.dev/tags: konflux
+spec:
+  description: |
+    The `rosa-hcp-provision` task automates the creation and provisioning of an ephemeral OpenShift cluster using Red Hat OpenShift on AWS (ROSA) with Hosted Control Planes (HCP).
+    The task takes several parameters, including the OpenShift version, AWS machine type, and cluster name, to configure and deploy the cluster on AWS.
+    It uses credentials stored in a Kubernetes secret for authentication and configuration of AWS and ROSA.
+    Once the cluster is provisioned, the task outputs a login command to access the newly created cluster, which can be used in subsequent pipeline steps.
+    The logs from cluster provisioning are than scanned for leaked credentials and pushed to specified OCI artifact
+  results:
+    - name: ocp-login-command
+      description: Command to log in to the newly ephemeral OpenShift cluster.
+    - name: oidc-config-id
+      description: The ID of the managed OIDC config created for this cluster. Must be passed to the deprovision task for cleanup.
+  params:
+    - name: ocp-version
+      type: string
+      description: The version of the OpenShift Container Platform (OCP) to deploy. This will be used to fetch the corresponding HCP version for deployment.
+    - name: cluster-name
+      type: string
+      description: The unique name of the OpenShift cluster to be created.
+    - name: machine-type
+      type: string
+      description: The AWS EC2 instance type to be used for the worker nodes of the OpenShift cluster (e.g., m5.xlarge).
+    - name: replicas
+      type: string
+      description: The number of worker nodes to provision in the cluster. Defaults to 3 worker nodes.
+      default: '3'
+    - name: konflux-test-infra-secret
+      type: string
+      description: The name of the Kubernetes secret that contains AWS and ROSA configuration credentials needed for cluster provisioning.
+    - name: cloud-credential-key
+      type: string
+      description: The key within the secret where AWS ROSA configurations (e.g., credentials, roles) are stored.
+    - name: oci-container
+      type: string
+      description: The ORAS container registry URI where artifacts will be stored.
+    - name: oci-credentials-secret
+      type: string
+      description: Name of the Kubernetes Secret containing OCI registry credentials for pushing artifacts.
+    - name: oci-credentials-secret-key
+      type: string
+      default: .dockerconfigjson
+      description: Key within the OCI credentials secret that holds the registry credentials in .dockerconfigjson format.
+    - name: tags
+      type: string
+      default: ''
+      description: |
+        Optional tags to apply to the cluster in key:value format, comma-separated (e.g. "env:staging,team:qe").
+        When empty, no tags are applied.
+  volumes:
+    - name: konflux-test-infra-volume
+      secret:
+        secretName: "$(params.konflux-test-infra-secret)"
+    - name: oci-credentials-volume
+      secret:
+        secretName: "$(params.oci-credentials-secret)"
+  steps:
+    - name: provision
+      image: quay.io/konflux-ci/tekton-integration-catalog/utils:latest
+      onError: continue
+      volumeMounts:
+        - name: konflux-test-infra-volume
+          mountPath: /usr/local/konflux-test-infra
+      workingDir: /workspace/cluster-provision
+      env:
+        - name: CLUSTER_NAME
+          value: "$(params.cluster-name)"
+        - name: OCP_VERSION
+          value: "$(params.ocp-version)"
+        - name: MACHINE_TYPE
+          value: "$(params.machine-type)"
+        - name: ADDITIONAL_TAGS
+          value: "$(params.tags)"
+      script: |
+        #!/bin/bash
+        set -euo pipefail
+
+        export ROSA_TOKEN AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY BILLING_ACCOUNT_ID \
+              SUBNET_IDS REGION OIDC_CONFIG_ID OPERATOR_ROLES_PREFIX
+
+        ROSA_TOKEN=$(jq -r '.aws["rosa-hcp"]["rosa-token"]' /usr/local/konflux-test-infra/$(params.cloud-credential-key))
+        AWS_ACCESS_KEY_ID=$(jq -r '.aws["access-key-id"]' /usr/local/konflux-test-infra/$(params.cloud-credential-key))
+        AWS_SECRET_ACCESS_KEY=$(jq -r '.aws["access-key-secret"]' /usr/local/konflux-test-infra/$(params.cloud-credential-key))
+        BILLING_ACCOUNT_ID=$(jq -r '.aws["aws-account-id"]' /usr/local/konflux-test-infra/$(params.cloud-credential-key))
+        SUBNET_IDS=$(jq -r '.aws["rosa-hcp"]["subnets-ids"]' /usr/local/konflux-test-infra/$(params.cloud-credential-key))
+        REGION=$(jq -r '.aws["region"]' /usr/local/konflux-test-infra/$(params.cloud-credential-key))
+        OPERATOR_ROLES_PREFIX="$CLUSTER_NAME"
+
+        main() {
+          config_aws_creds() {
+              printf "INFO: Configure AWS Credentials...\n"
+              aws configure set aws_access_key_id "$AWS_ACCESS_KEY_ID"
+              aws configure set aws_secret_access_key "$AWS_SECRET_ACCESS_KEY"
+              aws configure set region "$REGION"
+          }
+
+          print_debug_info() {
+              printf "INFO: Print debug info......\n"
+              rosa --region "$REGION" describe cluster --cluster="$CLUSTER_NAME"
+          }
+
+          wait_for() {
+              local command="${1}"
+              local description="${2}"
+              local timeout="${3}"
+              local interval="${4}"
+
+              printf "Waiting for %s for %s...\n" "${description}" "${timeout}"
+              timeout --foreground "${timeout}" bash -c "
+              until ${command}
+              do
+                  printf \"Waiting for %s... Trying again in ${interval}s\n\" \"${description}\"
+                  sleep ${interval}
+              done
+              " || return 1
+              printf "%s finished!\n" "${description}"
+          }
+
+          check_clusteroperators() {
+              wait_for "kubectl get clusteroperators -A" "cluster operators to be accessible" "2m" "10"
+              echo "[INFO] Cluster operators are accessible."
+          }
+
+          get_hcp_full_version() {
+              rosa_output=$(rosa list version --channel-group stable --region "$REGION" --hosted-cp -o json)
+              raw_id=$(echo "$rosa_output" | jq -r "[.[].raw_id | select(startswith(\"$OCP_VERSION\"))] | max")
+              HCP_FULL_VERSION="$raw_id"
+              if [ -z "$HCP_FULL_VERSION" ]; then
+                  echo "Failed to get the HCP full version of $OCP_VERSION" >&2
+                  exit 1
+              fi
+          }
+
+          check_cluster_health_endpoint() {
+              cluster_id=$(ocm get clusters --parameter search="name like '$CLUSTER_NAME'" | jq -r '.items[].id')
+              # 1. Wait for cluster to be reported as healthy
+              # 2. If the attempt fails, print out the list of cluster operators, which should provide a better overview about the current status of the cluster
+              wait_for "ocm get subs --parameter search=\"cluster_id = '$cluster_id'\" | jq -r '.items[0].metrics[0].health_state' | grep -E ^healthy || (kubectl get clusteroperators -A && false)" \
+                  "cluster to be reported as healthy" "60m" "60"
+          }
+
+          create_oidc_config() {
+              printf "INFO: Creating managed OIDC config...\n"
+              rosa create oidc-config --managed --mode=auto --region "$REGION" -y
+              OIDC_CONFIG_ID=$(rosa list oidc-config --region "$REGION" -o json | jq -r 'sort_by(.creation_timestamp) | last | .id')
+              if [ -z "$OIDC_CONFIG_ID" ] || [ "$OIDC_CONFIG_ID" = "null" ]; then
+                  echo "ERROR: Failed to get OIDC config ID after creation" >&2
+                  exit 1
+              fi
+              printf "INFO: Created OIDC config with ID: %s\n" "$OIDC_CONFIG_ID"
+              printf '%s' "$OIDC_CONFIG_ID" > "$(results.oidc-config-id.path)"
+          }
+
+          create_operator_roles() {
+              printf "INFO: Creating operator roles with prefix [%s] for OIDC config [%s]...\n" "$OPERATOR_ROLES_PREFIX" "$OIDC_CONFIG_ID"
+              INSTALL_ROLE_ARN=$(rosa list account-roles --region "$REGION" -o json | jq -r '[.[] | select(.RoleType | test("Installer")) | select(.RoleName | test("HCP"))] | first | .RoleARN')
+              if [ -z "$INSTALL_ROLE_ARN" ] || [ "$INSTALL_ROLE_ARN" = "null" ]; then
+                  echo "ERROR: Failed to discover installer account role" >&2
+                  exit 1
+              fi
+              rosa create operator-roles \
+                  --oidc-config-id "$OIDC_CONFIG_ID" \
+                  --prefix "$OPERATOR_ROLES_PREFIX" \
+                  --role-arn "$INSTALL_ROLE_ARN" \
+                  --region "$REGION" \
+                  --hosted-cp \
+                  --mode=auto -y
+          }
+
+          deploy_cluster() {
+              printf "INFO: Log in to your Red Hat account...\n"
+              config_aws_creds
+              rosa login --token="$ROSA_TOKEN"
+
+              create_oidc_config
+              create_operator_roles
+
+              printf "INFO: Create ROSA with HCP cluster...\n"
+              get_hcp_full_version
+              TAGS_ARG=()
+              if [ -n "$ADDITIONAL_TAGS" ]; then
+                  TAGS_ARG=(--tags "$ADDITIONAL_TAGS")
+              fi
+              rosa create cluster --cluster-name "$CLUSTER_NAME" \
+                  --sts --oidc-config-id "$OIDC_CONFIG_ID" \
+                  --operator-roles-prefix "$OPERATOR_ROLES_PREFIX" --region "$REGION" --version "$HCP_FULL_VERSION" \
+                  --compute-machine-type "$MACHINE_TYPE" \
+                  --subnet-ids="$SUBNET_IDS" \
+                  --billing-account "$BILLING_ACCOUNT_ID" \
+                  --replicas $(params.replicas) \
+                  "${TAGS_ARG[@]}" \
+                  --hosted-cp -y
+
+              printf "INFO: Track the progress of the cluster creation...\n"
+              rosa logs install --cluster="$CLUSTER_NAME" --region "$REGION" --watch
+
+              printf "INFO: ROSA with HCP cluster is ready, create a cluster admin account for accessing the cluster\n"
+              admin_output="$(rosa create admin --region "$REGION" --cluster="$CLUSTER_NAME")"
+
+              # Get the admin account credentials and API server URL
+              admin_user="$(echo "$admin_output" | grep -oP '(?<=--username ).*(?= --password)')"
+              admin_pass="$(echo "$admin_output" | grep -oP '(?<=--password ).*')"
+              api_url="$(echo "$admin_output" | grep -oP '(?<=oc login ).*(?= --username)')"
+
+              printf "INFO: Storing login command...\n"
+              echo "oc login $api_url --username $admin_user --password $admin_pass" > $(results.ocp-login-command.path)
+
+              # Use the admin account to login to the cluster in a loop until the account is active.
+              printf "INFO: Check if it's able to login to OCP cluster...\n"
+              max_retries=10
+              retries=0
+
+              while ! oc login "$api_url" --username "$admin_user" --password "$admin_pass" >/dev/null 2>&1; do
+                  if [ "$retries" -eq "$max_retries" ]; then
+                      echo "ERROR: Failed to login the cluster." >&2
+                      print_debug_info
+                      exit 1
+                  fi
+                  sleep 60
+                  retries=$((retries + 1))
+                  echo "Retried $retries times..."
+              done
+
+              #Workaround: Check if apiserver is ready by calling kubectl get nodes
+              printf "INFO: Check if apiserver is ready...\n"
+              if ! timeout 300s bash -c "while ! kubectl get nodes >/dev/null 2>/dev/null; do printf '.'; sleep 10; done"; then
+                  echo "ERROR: API server is not ready" >&2
+                  exit 1
+              fi
+              check_clusteroperators
+              check_cluster_health_endpoint
+          }
+
+          deploy_cluster
+        }
+        main 2>&1 | tee cluster-provision.log
+    - name: secure-push-oci
+      ref:
+        resolver: git
+        params:
+          - name: url
+            value: https://github.com/PabloHiro/tekton-integration-catalog.git
+          - name: revision
+            value: feature/rosa-hcp-provision-separate-oci-secret
+          - name: pathInRepo
+            value: stepactions/secure-push-oci/0.2/secure-push-oci.yaml
+      params:
+        - name: workdir-path
+          value: /workspace/cluster-provision
+        - name: oci-ref
+          value: $(params.oci-container)
+        - name: credentials-volume-name
+          value: oci-credentials-volume
+        - name: credentials-volume-key
+          value: $(params.oci-credentials-secret-key)
+    - name: fail-if-any-step-failed
+      ref:
+        resolver: git
+        params:
+          - name: url
+            value: https://github.com/konflux-ci/tekton-integration-catalog.git
+          - name: revision
+            value: main
+          - name: pathInRepo
+            value: stepactions/fail-if-any-step-failed/0.1/fail-if-any-step-failed.yaml


### PR DESCRIPTION
## Changes

### secure-push-oci 0.2
- Adds configurable `credentials-volume-key` param (was hardcoded to `oci-storage-dockerconfigjson` in 0.1).

### rosa-hcp-provision 0.3
- Separates OCI registry credentials from AWS/ROSA credentials into a dedicated `oci-credentials-secret` param.
- Uses `secure-push-oci` 0.2 with configurable `credentials-volume-key`.

### rosa-hcp-deprovision 0.3
- Same OCI credentials separation as provision 0.3.
- Uses `secure-push-oci` 0.2 with `onError: continue` to ensure cluster deprovisioning is never blocked by an artifact upload failure.
- Cleans up per-cluster operator roles and OIDC config when `oidc-config-id` is provided.