### PR TITLE
chore: bump coverport-cli image tag

### DIFF
--- a/stepactions/coverport-collect/0.1/coverport-collect.yaml
+++ b/stepactions/coverport-collect/0.1/coverport-collect.yaml
@@ -29,7 +29,7 @@ spec:
 
     For more information: https://github.com/konflux-ci/coverport
 
-  image: quay.io/konflux-ci/konflux-devprod/coverport-cli@sha256:bef3f7af97512649141bb273530be99f9afdebd6aaa1dfa795a0c84b5e322112
+  image: quay.io/konflux-ci/konflux-devprod/coverport-cli@sha256:44c180e1e3a3521b1057f4e85723efef2eb2107a153c9c5e91dfdb0f5631e41d
 
   params:
     - name: images
@@ -62,9 +62,11 @@ spec:
       default: ""
 
     - name: coverage-port
-      description: "Port where coverage server is listening in pods"
+      description: |
+        Port where coverage server is listening in pods.
+        Leave empty to auto-detect (tries 53700 then falls back to 9095).
       type: string
-      default: "9095"
+      default: ""
 
     - name: output-path
       description: |
@@ -195,7 +197,9 @@ spec:
     CMD="$CMD --output=$OUTPUT_PATH"
 
     # Collection options
-    CMD="$CMD --port=$COVERAGE_PORT"
+    if [ -n "$COVERAGE_PORT" ]; then
+      CMD="$CMD --port=$COVERAGE_PORT"
+    fi
     CMD="$CMD --timeout=$TIMEOUT"
 
     if [ -n "$COVERAGE_FILTERS" ]; then

--- a/stepactions/coverport-upload/0.1/coverport-upload.yaml
+++ b/stepactions/coverport-upload/0.1/coverport-upload.yaml
@@ -24,7 +24,7 @@ spec:
 
     More information: https://github.com/konflux-ci/coverport
 
-  image: quay.io/konflux-ci/konflux-devprod/coverport-cli@sha256:bef3f7af97512649141bb273530be99f9afdebd6aaa1dfa795a0c84b5e322112
+  image: quay.io/konflux-ci/konflux-devprod/coverport-cli@sha256:44c180e1e3a3521b1057f4e85723efef2eb2107a153c9c5e91dfdb0f5631e41d
 
   params:
     # Input parameters


### PR DESCRIPTION
# Description

Update coverport-cli image due to bump of the coverage-server version

# Verification

Tested with [this PR](https://github.com/konflux-ci/release-service/pull/1637)