### PR TITLE
fix: move to a stable image tag

### DIFF
--- a/tasks/mapt-oci/fedora-virtual-machine/deprovision/0.1/fedora-vm-deprovision.yaml
+++ b/tasks/mapt-oci/fedora-virtual-machine/deprovision/0.1/fedora-vm-deprovision.yaml
@@ -67,7 +67,7 @@ spec:
       default: "true"
   steps:
     - name: destroy
-      image: quay.io/redhat-developer/mapt:v1.0.0-dev
+      image: quay.io/redhat-developer/mapt:v0.9.9
       imagePullPolicy: Always
       env:
         - name: HOME


### PR DESCRIPTION
Using a floating tag is prone to breaking the task, moving to a stable tag