### PR TITLE
fix: clean up orphaned mapt VPCs without NAT gws

### DIFF
--- a/scripts/mapt/README.md
+++ b/scripts/mapt/README.md
@@ -2,7 +2,7 @@
 
 This script is designed for periodic execution in a CI/CD pipeline to automatically clean up orphaned AWS resources associated with clusters provisioned by the `github.com/redhat-developer/mapt` tool.
 
-It identifies resources that are tagged with **`origin=mapt`** and have been running for **longer than 1 day (86,400 seconds)**, then attempts a comprehensive teardown of the associated VPC infrastructure based on the shared **`projectName`** tag.
+It identifies resources that are tagged with **`origin=mapt`** and have been running for **longer than 1 day (86,400 seconds)**, then attempts a comprehensive teardown of the associated VPC infrastructure based on the shared **`projectName`** tag. For orphaned VPCs with no EC2 instance history, the script uses **CloudTrail** `CreateVpc` events to determine VPC age; VPCs with no CloudTrail event are assumed older than the 90-day retention period and deleted.
 
 ---
 
@@ -12,7 +12,7 @@ This script performs **irreversible delete operations** on AWS infrastructure. *
 
 ### Prerequisites
 
-1.  **AWS CLI:** Installed and configured with credentials that have sufficient deletion permissions for all target resource types across all regions.
+1.  **AWS CLI:** Installed and configured with credentials that have sufficient permissions for deletion of all target resource types across all regions, plus `cloudtrail:LookupEvents` for VPC age verification.
 2.  **`bash`:** The script is written in Bash.
 3.  **`jq`:** The command-line JSON processor is required for parsing complex AWS CLI output.
 4.  **`date`:** A version of the `date` utility capable of parsing ISO 8601 timestamps (e.g., GNU `date`, common on Linux/macOS).

--- a/scripts/mapt/delete-mapt-clusters.sh
+++ b/scripts/mapt/delete-mapt-clusters.sh
@@ -3,10 +3,10 @@
 # --- Configuration ---
 TAG_KEY="origin"
 TAG_VALUE="mapt"
-PROJECT_TAG_KEY="projectName" 
+PROJECT_TAG_KEY="projectName"
 FILTER="Name=tag:$TAG_KEY,Values=$TAG_VALUE"
 # 1 day (86400 seconds)
-AGE_LIMIT_SECONDS=$((24 * 60 * 60)) 
+AGE_LIMIT_SECONDS=$((24 * 60 * 60))
 
 # --- Command Line Argument Handling ---
 DRY_RUN=false
@@ -45,7 +45,7 @@ get_age_seconds() {
     local timestamp="$1"
     local epoch_time=$(date -u -d "$timestamp" +%s 2>/dev/null)
     local current_epoch=$(date +%s)
-    
+
     if [ -z "$epoch_time" ] || [ "$epoch_time" -eq 0 ]; then
         echo 0
     else
@@ -67,19 +67,20 @@ wait_for_resource_deletion() {
     fi
 
     echo "   [PAUSE] Polling until $type $id is deleted (max 5 min)..."
-    
+
     while [ "$attempts" -lt "$max_attempts" ]; do
         attempts=$((attempts + 1))
-        
+
         # Check if the resource still exists
         local exists_check=""
         case "$type" in
             ENI)
                 exists_check=$(aws ec2 describe-network-interfaces --region "$region" --network-interface-ids "$id" --query 'NetworkInterfaces[0].NetworkInterfaceId' --output text 2>/dev/null)
                 ;;
-            # Add other complex polling checks here if needed (e.g., LB deletion)
+            LB)
+                exists_check=$(aws elbv2 describe-load-balancers --region "$region" --load-balancer-arns "$id" --query 'LoadBalancers[0].LoadBalancerArn' --output text 2>/dev/null)
+                ;;
             *)
-                # For simplicity, if we don't have a dedicated check, we stop polling.
                 return 0
                 ;;
         esac
@@ -91,7 +92,7 @@ wait_for_resource_deletion() {
 
         sleep "$interval"
     done
-    
+
     echo "   [WARNING] $type $id did not delete within the time limit. Continuing cleanup."
     return 1 # Failure to confirm deletion
 }
@@ -194,11 +195,11 @@ delete_resource() {
 # Loop through each region
 for region in $regions; do
   echo "Checking region: $region"
-  
+
   # Initialize regional counters and storage for VPCs targeted for final deletion
   regional_vpc_count=0
-  regional_vpcs_to_delete="" 
-  
+  regional_vpcs_to_delete=""
+
   regional_subnets=0
   regional_sgs=0
   regional_endpoints=0
@@ -206,7 +207,7 @@ for region in $regions; do
   regional_igws=0
   regional_ec2s=0
   regional_eips=0
-  regional_enis=0 
+  regional_enis=0
   regional_peering=0
   regional_acls=0
   regional_vpns=0
@@ -249,7 +250,7 @@ for region in $regions; do
   # -----------------------------------------------------------------
   # 1. VPC IDENTIFICATION (via NAT Gateway)
   # -----------------------------------------------------------------
-  
+
   # 1.1 Get JSON data for tagged NAT Gateways
   nat_gateways_json=$(
     aws ec2 describe-nat-gateways \
@@ -262,50 +263,50 @@ for region in $regions; do
   # NOTE: Finding the NAT Gateway's ENI ID for polling
   nat_gateways_data=$(
     echo "$nat_gateways_json" | \
-    jq -r '.NatGateways[] | select(.State == "available") | 
-        .VpcId + "," + 
-        .CreateTime + "," + 
-        .NatGatewayId + "," + 
-        (.Tags[] | select(.Key == "'"$PROJECT_TAG_KEY"'") | .Value) + "," + 
+    jq -r '.NatGateways[] | select(.State == "available") |
+        .VpcId + "," +
+        .CreateTime + "," +
+        .NatGatewayId + "," +
+        (.Tags[] | select(.Key == "'"$PROJECT_TAG_KEY"'") | .Value) + "," +
         .NatGatewayAddresses[0].NetworkInterfaceId
     ' 2>/dev/null
   )
 
-  counted_vpcs_string="|" 
+  counted_vpcs_string="|"
 
   while IFS=',' read -r vpc_id create_time nat_gw_id project_name nat_eni_id; do
-    
+
     if [ -z "$vpc_id" ] || [ -z "$project_name" ]; then
       continue
     fi
-    
+
     if echo "$counted_vpcs_string" | grep -q "|${vpc_id}|"; then
       continue
     fi
-    
+
     age_seconds=$(get_age_seconds "$create_time")
-    
+
     if [ "$age_seconds" -gt "$AGE_LIMIT_SECONDS" ]; then
-      
+
       echo "  --------------------------------------------------"
       echo "  ✅ OLD VPC INFRASTRUCTURE FOUND (Proxy: $nat_gw_id)"
       echo "     VPC ID: $vpc_id"
       echo "     Project: $project_name"
       echo "     Created: $create_time"
-      
+
       # Mark VPC as counted and store it for final deletion pass
       regional_vpc_count=$((regional_vpc_count + 1))
       regional_vpcs_to_delete="$regional_vpcs_to_delete $vpc_id"
-      counted_vpcs_string="${counted_vpcs_string}${vpc_id}|" 
-      
+      counted_vpcs_string="${counted_vpcs_string}${vpc_id}|"
+
       # -----------------------------------------------------------------
       # 2. DELETE/REPORT ASSOCIATED RESOURCES by PROJECT TAG or VPC ID
       # -----------------------------------------------------------------
       PROJECT_FILTER="Name=tag:$PROJECT_TAG_KEY,Values=$project_name"
       VPC_FILTER="Name=vpc-id,Values=$vpc_id"
-      
+
       echo "  Searching for related resources with Tag: $PROJECT_TAG_KEY=$project_name and VPC: $vpc_id..."
-      
+
       # --- 2.1 Load Balancers (Deletes ELA ENIs automatically) ---
       # Filter Load Balancers by VPC ID, then delete them.
       lbs_arns_in_vpc=$(
@@ -314,7 +315,7 @@ for region in $regions; do
             --query "LoadBalancers[?VpcId=='$vpc_id'].LoadBalancerArn" \
             --output text 2>/dev/null
       )
-      
+
       for lb_arn in $lbs_arns_in_vpc; do
           delete_resource "LB" "$lb_arn" "$region" "Associated with old project"
           regional_lbs=$((regional_lbs + 1))
@@ -335,7 +336,7 @@ for region in $regions; do
               regional_ec2s=$((regional_ec2s + 1))
           fi
       done <<< "$ec2s_project_time"
-      
+
       # --- 2.3 NAT Gateway (Deletion and Poll) ---
       delete_resource "NAT_GW_PROXY" "$nat_gw_id" "$region" "$create_time"
       wait_for_resource_deletion "ENI" "$nat_eni_id" "$region"
@@ -348,7 +349,7 @@ for region in $regions; do
 
           # --- 2.4.1 Deletion of ELASTIC IP (EIP) (Catch remaining) ---
           eips_data=$(aws ec2 describe-addresses --region "$region" --query "Addresses[?NetworkInterfaceId=='$eni_id'].AllocationId"  --output text 2>/dev/null)
-          
+
           for eip_alloc_id in $eips_data; do
               delete_resource "EIP" "$eip_alloc_id" "$region" "Associated with old project"
               regional_eips=$((regional_eips + 1))
@@ -361,14 +362,14 @@ for region in $regions; do
           delete_resource "ENDPOINT" "$ep_id" "$region" "Associated with old project"
           regional_endpoints=$((regional_endpoints + 1))
       done
-      
+
       # --- 2.6 VPC Peering Connections ---
       peering_conns=$(aws ec2 describe-vpc-peering-connections --region "$region" --filter "Name=requester-vpc-info.vpc-id,Values=$vpc_id" --query 'VpcPeeringConnections[].VpcPeeringConnectionId' --output text 2>/dev/null)
       for pcx_id in $peering_conns; do
           delete_resource "PEERING" "$pcx_id" "$region" "Associated with old project"
           regional_peering=$((regional_peering + 1))
       done
-      
+
       # --- 2.7 VPN Gateways (Detach and Delete) ---
       vpn_gws=$(aws ec2 describe-vpn-gateways --region "$region" --filter "Name=attachment.vpc-id,Values=$vpc_id" --query 'VpnGateways[].VpnGatewayId' --output text 2>/dev/null)
       for vpn_id in $vpn_gws; do
@@ -382,7 +383,7 @@ for region in $regions; do
           delete_resource "CARRIER_GW" "$carrier_id" "$region" "Associated with old project"
           regional_carriers=$((regional_carriers + 1))
       done
-      
+
       # --- 2.9 Local Gateway Route Table VPC Associations ---
       lgw_assocs=$(aws ec2 describe-local-gateway-route-table-vpc-associations --region "$region" --filter "$VPC_FILTER" --query 'LocalGatewayRouteTableVpcAssociations[].LocalGatewayRouteTableVpcAssociationId' --output text 2>/dev/null)
       for assoc_id in $lgw_assocs; do
@@ -397,7 +398,7 @@ for region in $regions; do
           delete_resource "IGW" "$igw_id" "$region" "Associated with old project"
           regional_igws=$((regional_igws + 1))
       done
-      
+
       # --- 2.11 Route Tables ---
       rts=$(aws ec2 describe-route-tables --region "$region" --query "RouteTables[?VpcId=='$vpc_id'].RouteTableId" --output text 2>/dev/null)
       for rt_id in $rts; do
@@ -407,7 +408,7 @@ for region in $regions; do
              regional_rts=$((regional_rts + 1))
           fi
       done
-      
+
       # --- 2.12 Network ACLs ---
       acls=$(aws ec2 describe-network-acls --region "$region" --filter "$VPC_FILTER" --query 'NetworkAcls[?IsDefault == `false`].NetworkAclId' --output text 2>/dev/null)
       for acl_id in $acls; do
@@ -421,7 +422,7 @@ for region in $regions; do
           delete_resource "SUBNET" "$subnet_id" "$region" "Associated with old project"
           regional_subnets=$((regional_subnets + 1))
       done
-      
+
       # --- 2.14 Security Groups ---
       sgs=$(aws ec2 describe-security-groups --region "$region" --filter "$VPC_FILTER" --query 'SecurityGroups[].GroupId' --output text 2>/dev/null)
       for sg_id in $sgs; do
@@ -432,8 +433,200 @@ for region in $regions; do
       done
     fi
   done <<< "$nat_gateways_data"
-  
-  
+
+  # -----------------------------------------------------------------
+  # 3. ORPHANED VPC CLEANUP (VPCs without NAT Gateways, e.g. kind clusters)
+  # mapt kind clusters use NatGatewayModeNone — no NAT gateway is created,
+  # so the NAT-gateway-based discovery above never finds them.
+  # We discover these VPCs directly by the origin=mapt tag, then check
+  # for EC2 instance presence to determine if the cluster is still active.
+  # -----------------------------------------------------------------
+  orphan_vpcs=$(
+      aws ec2 describe-vpcs \
+        --region "$region" \
+        --filters "$FILTER" \
+        --query 'Vpcs[].VpcId' \
+        --output text 2>/dev/null
+  )
+
+  for vpc_id in $orphan_vpcs; do
+      # Skip VPCs already handled by the NAT gateway path
+      if echo "$counted_vpcs_string" | grep -q "|${vpc_id}|"; then
+          continue
+      fi
+
+      # Check for any non-terminated EC2 instances in this VPC
+      active_instances=$(
+          aws ec2 describe-instances \
+            --region "$region" \
+            --filters "Name=vpc-id,Values=$vpc_id" \
+            --query 'Reservations[].Instances[?State.Name!=`terminated`].InstanceId' \
+            --output text 2>/dev/null
+      )
+      if [ -n "$active_instances" ]; then
+          continue
+      fi
+
+      # Check for terminated instances to apply the age limit
+      terminated_data=$(
+          aws ec2 describe-instances \
+            --region "$region" \
+            --filters "Name=vpc-id,Values=$vpc_id" "Name=instance-state-name,Values=terminated" \
+            --query 'Reservations[].Instances[].LaunchTime' \
+            --output text 2>/dev/null
+      )
+      if [ -n "$terminated_data" ]; then
+          # Use the most recent LaunchTime among terminated instances
+          skip_vpc=false
+          for launch_time in $terminated_data; do
+              age_seconds=$(get_age_seconds "$launch_time")
+              if [ "$age_seconds" -le "$AGE_LIMIT_SECONDS" ]; then
+                  skip_vpc=true
+                  break
+              fi
+          done
+          if $skip_vpc; then
+              continue
+          fi
+      fi
+      # No instances at all (purged from API >1h after termination) or
+      # only terminated instances older than the age limit — VPC is orphaned.
+
+      project_name=$(
+          aws ec2 describe-vpcs \
+            --region "$region" \
+            --vpc-ids "$vpc_id" \
+            --query "Vpcs[0].Tags[?Key=='$PROJECT_TAG_KEY'].Value" \
+            --output text 2>/dev/null
+      )
+      project_name="${project_name:-unknown}"
+
+      echo "  --------------------------------------------------"
+      echo "  ✅ ORPHANED VPC FOUND (no NAT Gateway, no active instances)"
+      echo "     VPC ID: $vpc_id"
+      echo "     Project: $project_name"
+
+      regional_vpc_count=$((regional_vpc_count + 1))
+      regional_vpcs_to_delete="$regional_vpcs_to_delete $vpc_id"
+      counted_vpcs_string="${counted_vpcs_string}${vpc_id}|"
+
+      VPC_FILTER="Name=vpc-id,Values=$vpc_id"
+
+      echo "  Cleaning up orphaned VPC dependencies for $vpc_id..."
+
+      # --- 3.1 Load Balancers (async deletion — must wait before ENI/EIP cleanup) ---
+      lbs_arns_in_vpc=$(
+          aws elbv2 describe-load-balancers \
+            --region "$region" \
+            --query "LoadBalancers[?VpcId=='$vpc_id'].LoadBalancerArn" \
+            --output text 2>/dev/null
+      )
+      for lb_arn in $lbs_arns_in_vpc; do
+          delete_resource "LB" "$lb_arn" "$region" "Orphaned VPC cleanup"
+          wait_for_resource_deletion "LB" "$lb_arn" "$region"
+          regional_lbs=$((regional_lbs + 1))
+      done
+
+      # --- 3.2 Elastic Network Interfaces + associated EIPs ---
+      enis=$(aws ec2 describe-network-interfaces --region "$region" --filter "$VPC_FILTER" --query 'NetworkInterfaces[].{Id:NetworkInterfaceId,Type:InterfaceType}' --output text 2>/dev/null)
+      while read -r eni_id eni_type; do
+          if [ -z "$eni_id" ]; then
+              continue
+          fi
+          # Skip ELB-managed ENIs — they are auto-deleted after LB deletion completes
+          if [ "$eni_type" = "network_load_balancer" ] || [ "$eni_type" = "elastic_load_balancing" ]; then
+              continue
+          fi
+          eips_data=$(aws ec2 describe-addresses --region "$region" --query "Addresses[?NetworkInterfaceId=='$eni_id'].AllocationId" --output text 2>/dev/null)
+          for eip_alloc_id in $eips_data; do
+              delete_resource "EIP" "$eip_alloc_id" "$region" "Orphaned VPC cleanup"
+              regional_eips=$((regional_eips + 1))
+          done
+          delete_resource "ENI" "$eni_id" "$region" "Orphaned VPC cleanup"
+          regional_enis=$((regional_enis + 1))
+      done <<< "$enis"
+
+      # --- 3.3 Standalone EIPs tagged with origin=mapt in this VPC ---
+      # (EIPs not attached to an ENI won't be caught above)
+      standalone_eips=$(aws ec2 describe-addresses --region "$region" --filters "$FILTER" --query "Addresses[?AssociationId==null].AllocationId" --output text 2>/dev/null)
+      for eip_alloc_id in $standalone_eips; do
+          delete_resource "EIP" "$eip_alloc_id" "$region" "Orphaned standalone EIP"
+          regional_eips=$((regional_eips + 1))
+      done
+
+      # --- 3.4 VPC Endpoints ---
+      endpoints=$(aws ec2 describe-vpc-endpoints --region "$region" --filter "$VPC_FILTER" --query 'VpcEndpoints[].VpcEndpointId' --output text 2>/dev/null)
+      for ep_id in $endpoints; do
+          delete_resource "ENDPOINT" "$ep_id" "$region" "Orphaned VPC cleanup"
+          regional_endpoints=$((regional_endpoints + 1))
+      done
+
+      # --- 3.5 VPC Peering Connections ---
+      peering_conns=$(aws ec2 describe-vpc-peering-connections --region "$region" --filter "Name=requester-vpc-info.vpc-id,Values=$vpc_id" --query 'VpcPeeringConnections[].VpcPeeringConnectionId' --output text 2>/dev/null)
+      for pcx_id in $peering_conns; do
+          delete_resource "PEERING" "$pcx_id" "$region" "Orphaned VPC cleanup"
+          regional_peering=$((regional_peering + 1))
+      done
+
+      # --- 3.6 VPN Gateways ---
+      vpn_gws=$(aws ec2 describe-vpn-gateways --region "$region" --filter "Name=attachment.vpc-id,Values=$vpc_id" --query 'VpnGateways[].VpnGatewayId' --output text 2>/dev/null)
+      for vpn_id in $vpn_gws; do
+          delete_resource "VPN_GW" "$vpn_id" "$region" "Orphaned VPC cleanup"
+          regional_vpns=$((regional_vpns + 1))
+      done
+
+      # --- 3.7 Carrier Gateways ---
+      carrier_gws=$(aws ec2 describe-carrier-gateways --region "$region" --filter "$VPC_FILTER" --query 'CarrierGateways[].CarrierGatewayId' --output text 2>/dev/null)
+      for carrier_id in $carrier_gws; do
+          delete_resource "CARRIER_GW" "$carrier_id" "$region" "Orphaned VPC cleanup"
+          regional_carriers=$((regional_carriers + 1))
+      done
+
+      # --- 3.8 Local Gateway Route Table VPC Associations ---
+      lgw_assocs=$(aws ec2 describe-local-gateway-route-table-vpc-associations --region "$region" --filter "$VPC_FILTER" --query 'LocalGatewayRouteTableVpcAssociations[].LocalGatewayRouteTableVpcAssociationId' --output text 2>/dev/null)
+      for assoc_id in $lgw_assocs; do
+          delete_resource "LGW_ASSOC" "$assoc_id" "$region" "Orphaned VPC cleanup"
+          regional_lgw_assoc=$((regional_lgw_assoc + 1))
+      done
+
+      # --- 3.9 Internet Gateways (Detach and Delete) ---
+      igws=$(aws ec2 describe-internet-gateways --region "$region" --query "InternetGateways[?Attachments[0].VpcId=='$vpc_id'].InternetGatewayId" --output text 2>/dev/null)
+      for igw_id in $igws; do
+          delete_resource "IGW" "$igw_id" "$region" "Orphaned VPC cleanup"
+          regional_igws=$((regional_igws + 1))
+      done
+
+      # --- 3.10 Route Tables (skip main) ---
+      rts=$(aws ec2 describe-route-tables --region "$region" --query "RouteTables[?VpcId=='$vpc_id'].RouteTableId" --output text 2>/dev/null)
+      for rt_id in $rts; do
+          is_main=$(aws ec2 describe-route-tables --region "$region" --route-table-ids "$rt_id" --query 'RouteTables[0].Associations[?Main == `true`].Main' --output text 2>/dev/null)
+          if [ -z "$is_main" ]; then
+              delete_resource "RT" "$rt_id" "$region" "Orphaned VPC cleanup"
+              regional_rts=$((regional_rts + 1))
+          fi
+      done
+
+      # --- 3.11 Network ACLs (skip default) ---
+      acls=$(aws ec2 describe-network-acls --region "$region" --filter "$VPC_FILTER" --query 'NetworkAcls[?IsDefault == `false`].NetworkAclId' --output text 2>/dev/null)
+      for acl_id in $acls; do
+          delete_resource "ACL" "$acl_id" "$region" "Orphaned VPC cleanup"
+          regional_acls=$((regional_acls + 1))
+      done
+
+      # --- 3.12 Subnets ---
+      subnets=$(aws ec2 describe-subnets --region "$region" --filter "$VPC_FILTER" --query 'Subnets[].SubnetId' --output text 2>/dev/null)
+      for subnet_id in $subnets; do
+          delete_resource "SUBNET" "$subnet_id" "$region" "Orphaned VPC cleanup"
+          regional_subnets=$((regional_subnets + 1))
+      done
+
+      # --- 3.13 Security Groups (skip default) ---
+      sgs=$(aws ec2 describe-security-groups --region "$region" --filter "$VPC_FILTER" --query "SecurityGroups[?GroupName!='default'].GroupId" --output text 2>/dev/null)
+      for sg_id in $sgs; do
+          delete_resource "SG" "$sg_id" "$region" "Orphaned VPC cleanup"
+          regional_sgs=$((regional_sgs + 1))
+      done
+  done
 
   # -----------------------------------------------------------------
   # 4. FINAL VPC DELETION PASS (After all dependencies are removed)
@@ -448,7 +641,7 @@ for region in $regions; do
   # -----------------------------------------------------------------
   # 5. Print Regional Summary & Update Grand Totals
   # -----------------------------------------------------------------
-  
+
   if (( regional_vpc_count > 0 || regional_ec2s > 0 || regional_eips > 0 || regional_subnets > 0 || regional_sgs > 0 || regional_endpoints > 0 || regional_rts > 0 || regional_igws > 0 || regional_enis > 0 || regional_peering > 0 || regional_acls > 0 || regional_vpns > 0 || regional_carriers > 0 || regional_lgw_assoc > 0 || regional_lbs > 0 )); then
     echo "  Summary of actions in $region:"
     echo "    VPCs targeted for final delete:     $regional_vpc_count"
@@ -466,7 +659,7 @@ for region in $regions; do
     echo "    Subnets targeted:                   $regional_subnets"
     echo "    Security Groups targeted:           $regional_sgs"
     echo "    Elastic IPs (Tag match only) targeted: $regional_eips"
-    
+
     # Update global totals
     total_vpcs=$((total_vpcs + regional_vpc_count))
     total_lbs=$((total_lbs + regional_lbs))

--- a/scripts/mapt/delete-mapt-clusters.sh
+++ b/scripts/mapt/delete-mapt-clusters.sh
@@ -550,8 +550,14 @@ for region in $regions; do
           if [ -z "$eni_id" ]; then
               continue
           fi
-          # Skip ELB-managed ENIs — they are auto-deleted after LB deletion completes
+          # ELB-managed ENIs are auto-deleted after LB deletion, but their EIPs
+          # must be released first — otherwise IGW detach fails with DependencyViolation.
           if [ "$eni_type" = "network_load_balancer" ] || [ "$eni_type" = "elastic_load_balancing" ]; then
+              eips_data=$(aws ec2 describe-addresses --region "$region" --query "Addresses[?NetworkInterfaceId=='$eni_id'].AllocationId" --output text 2>/dev/null)
+              for eip_alloc_id in $eips_data; do
+                  delete_resource "EIP" "$eip_alloc_id" "$region" "ELB ENI EIP release"
+                  regional_eips=$((regional_eips + 1))
+              done
               continue
           fi
           eips_data=$(aws ec2 describe-addresses --region "$region" --query "Addresses[?NetworkInterfaceId=='$eni_id'].AllocationId" --output text 2>/dev/null)

--- a/scripts/mapt/delete-mapt-clusters.sh
+++ b/scripts/mapt/delete-mapt-clusters.sh
@@ -214,6 +214,7 @@ for region in $regions; do
   regional_carriers=0
   regional_lgw_assoc=0
   regional_lbs=0
+  orphan_project_names=""
 
   # -----------------------------------------------------------------
   # TOP priority: Delete EC2 instances
@@ -476,7 +477,6 @@ for region in $regions; do
             --output text 2>/dev/null
       )
       if [ -n "$terminated_data" ]; then
-          # Use the most recent LaunchTime among terminated instances
           skip_vpc=false
           for launch_time in $terminated_data; do
               age_seconds=$(get_age_seconds "$launch_time")
@@ -488,9 +488,25 @@ for region in $regions; do
           if $skip_vpc; then
               continue
           fi
+      else
+          # No instances at all — use CloudTrail CreateVpc event for age check
+          vpc_create_time=$(
+              aws cloudtrail lookup-events \
+                --region "$region" \
+                --lookup-attributes "AttributeKey=ResourceName,AttributeValue=$vpc_id" \
+                --query "Events[?EventName=='CreateVpc'].EventTime | [0]" \
+                --output text 2>/dev/null
+          )
+          if [ -n "$vpc_create_time" ] && [ "$vpc_create_time" != "None" ]; then
+              age_seconds=$(get_age_seconds "$vpc_create_time")
+              if [ "$age_seconds" -le "$AGE_LIMIT_SECONDS" ]; then
+                  echo "  ⏳ Skipping VPC $vpc_id — created $((age_seconds / 3600))h ago (< ${AGE_LIMIT_SECONDS}s limit, from CloudTrail)"
+                  continue
+              fi
+          else
+              echo "  ℹ️  No CloudTrail CreateVpc event for VPC $vpc_id — older than 90d retention, proceeding with deletion"
+          fi
       fi
-      # No instances at all (purged from API >1h after termination) or
-      # only terminated instances older than the age limit — VPC is orphaned.
 
       project_name=$(
           aws ec2 describe-vpcs \
@@ -509,6 +525,7 @@ for region in $regions; do
       regional_vpc_count=$((regional_vpc_count + 1))
       regional_vpcs_to_delete="$regional_vpcs_to_delete $vpc_id"
       counted_vpcs_string="${counted_vpcs_string}${vpc_id}|"
+      orphan_project_names="${orphan_project_names}|${project_name}|"
 
       VPC_FILTER="Name=vpc-id,Values=$vpc_id"
 
@@ -546,57 +563,49 @@ for region in $regions; do
           regional_enis=$((regional_enis + 1))
       done <<< "$enis"
 
-      # --- 3.3 Standalone EIPs tagged with origin=mapt in this VPC ---
-      # (EIPs not attached to an ENI won't be caught above)
-      standalone_eips=$(aws ec2 describe-addresses --region "$region" --filters "$FILTER" --query "Addresses[?AssociationId==null].AllocationId" --output text 2>/dev/null)
-      for eip_alloc_id in $standalone_eips; do
-          delete_resource "EIP" "$eip_alloc_id" "$region" "Orphaned standalone EIP"
-          regional_eips=$((regional_eips + 1))
-      done
-
-      # --- 3.4 VPC Endpoints ---
+      # --- 3.3 VPC Endpoints ---
       endpoints=$(aws ec2 describe-vpc-endpoints --region "$region" --filter "$VPC_FILTER" --query 'VpcEndpoints[].VpcEndpointId' --output text 2>/dev/null)
       for ep_id in $endpoints; do
           delete_resource "ENDPOINT" "$ep_id" "$region" "Orphaned VPC cleanup"
           regional_endpoints=$((regional_endpoints + 1))
       done
 
-      # --- 3.5 VPC Peering Connections ---
+      # --- 3.4 VPC Peering Connections ---
       peering_conns=$(aws ec2 describe-vpc-peering-connections --region "$region" --filter "Name=requester-vpc-info.vpc-id,Values=$vpc_id" --query 'VpcPeeringConnections[].VpcPeeringConnectionId' --output text 2>/dev/null)
       for pcx_id in $peering_conns; do
           delete_resource "PEERING" "$pcx_id" "$region" "Orphaned VPC cleanup"
           regional_peering=$((regional_peering + 1))
       done
 
-      # --- 3.6 VPN Gateways ---
+      # --- 3.5 VPN Gateways ---
       vpn_gws=$(aws ec2 describe-vpn-gateways --region "$region" --filter "Name=attachment.vpc-id,Values=$vpc_id" --query 'VpnGateways[].VpnGatewayId' --output text 2>/dev/null)
       for vpn_id in $vpn_gws; do
           delete_resource "VPN_GW" "$vpn_id" "$region" "Orphaned VPC cleanup"
           regional_vpns=$((regional_vpns + 1))
       done
 
-      # --- 3.7 Carrier Gateways ---
+      # --- 3.6 Carrier Gateways ---
       carrier_gws=$(aws ec2 describe-carrier-gateways --region "$region" --filter "$VPC_FILTER" --query 'CarrierGateways[].CarrierGatewayId' --output text 2>/dev/null)
       for carrier_id in $carrier_gws; do
           delete_resource "CARRIER_GW" "$carrier_id" "$region" "Orphaned VPC cleanup"
           regional_carriers=$((regional_carriers + 1))
       done
 
-      # --- 3.8 Local Gateway Route Table VPC Associations ---
+      # --- 3.7 Local Gateway Route Table VPC Associations ---
       lgw_assocs=$(aws ec2 describe-local-gateway-route-table-vpc-associations --region "$region" --filter "$VPC_FILTER" --query 'LocalGatewayRouteTableVpcAssociations[].LocalGatewayRouteTableVpcAssociationId' --output text 2>/dev/null)
       for assoc_id in $lgw_assocs; do
           delete_resource "LGW_ASSOC" "$assoc_id" "$region" "Orphaned VPC cleanup"
           regional_lgw_assoc=$((regional_lgw_assoc + 1))
       done
 
-      # --- 3.9 Internet Gateways (Detach and Delete) ---
+      # --- 3.8 Internet Gateways (Detach and Delete) ---
       igws=$(aws ec2 describe-internet-gateways --region "$region" --query "InternetGateways[?Attachments[0].VpcId=='$vpc_id'].InternetGatewayId" --output text 2>/dev/null)
       for igw_id in $igws; do
           delete_resource "IGW" "$igw_id" "$region" "Orphaned VPC cleanup"
           regional_igws=$((regional_igws + 1))
       done
 
-      # --- 3.10 Route Tables (skip main) ---
+      # --- 3.9 Route Tables (skip main) ---
       rts=$(aws ec2 describe-route-tables --region "$region" --query "RouteTables[?VpcId=='$vpc_id'].RouteTableId" --output text 2>/dev/null)
       for rt_id in $rts; do
           is_main=$(aws ec2 describe-route-tables --region "$region" --route-table-ids "$rt_id" --query 'RouteTables[0].Associations[?Main == `true`].Main' --output text 2>/dev/null)
@@ -606,27 +615,46 @@ for region in $regions; do
           fi
       done
 
-      # --- 3.11 Network ACLs (skip default) ---
+      # --- 3.10 Network ACLs (skip default) ---
       acls=$(aws ec2 describe-network-acls --region "$region" --filter "$VPC_FILTER" --query 'NetworkAcls[?IsDefault == `false`].NetworkAclId' --output text 2>/dev/null)
       for acl_id in $acls; do
           delete_resource "ACL" "$acl_id" "$region" "Orphaned VPC cleanup"
           regional_acls=$((regional_acls + 1))
       done
 
-      # --- 3.12 Subnets ---
+      # --- 3.11 Subnets ---
       subnets=$(aws ec2 describe-subnets --region "$region" --filter "$VPC_FILTER" --query 'Subnets[].SubnetId' --output text 2>/dev/null)
       for subnet_id in $subnets; do
           delete_resource "SUBNET" "$subnet_id" "$region" "Orphaned VPC cleanup"
           regional_subnets=$((regional_subnets + 1))
       done
 
-      # --- 3.13 Security Groups (skip default) ---
+      # --- 3.12 Security Groups (skip default) ---
       sgs=$(aws ec2 describe-security-groups --region "$region" --filter "$VPC_FILTER" --query "SecurityGroups[?GroupName!='default'].GroupId" --output text 2>/dev/null)
       for sg_id in $sgs; do
           delete_resource "SG" "$sg_id" "$region" "Orphaned VPC cleanup"
           regional_sgs=$((regional_sgs + 1))
       done
   done
+
+  # -----------------------------------------------------------------
+  # 3.x Standalone EIPs tagged origin=mapt (single regional pass)
+  # EIPs have no VPC linkage when unassociated, so we scope deletion
+  # to EIPs whose projectName matches an orphan project identified above.
+  # -----------------------------------------------------------------
+  if [ -n "$orphan_project_names" ]; then
+      standalone_eips=$(aws ec2 describe-addresses --region "$region" --filters "$FILTER" --query "Addresses[?AssociationId==null].{Id:AllocationId,Tags:Tags}" --output json 2>/dev/null)
+      eip_count=$(echo "$standalone_eips" | jq 'length')
+      for i in $(seq 0 $((eip_count - 1))); do
+          eip_alloc_id=$(echo "$standalone_eips" | jq -r ".[$i].Id")
+          eip_project=$(echo "$standalone_eips" | jq -r ".[$i].Tags[]? | select(.Key==\"$PROJECT_TAG_KEY\") | .Value // \"unknown\"")
+          eip_project="${eip_project:-unknown}"
+          if echo "$orphan_project_names" | grep -q "|${eip_project}|"; then
+              delete_resource "EIP" "$eip_alloc_id" "$region" "Orphaned standalone EIP (project: $eip_project)"
+              regional_eips=$((regional_eips + 1))
+          fi
+      done
+  fi
 
   # -----------------------------------------------------------------
   # 4. FINAL VPC DELETION PASS (After all dependencies are removed)


### PR DESCRIPTION
## Summary
- Add orphaned VPC cleanup for mapt clusters that don't create NAT gateways
  (kind clusters use `NatGatewayModeNone` — confirmed in mapt source code)
- VPCs are discovered by `origin=mapt` tag, then filtered by EC2 instance
  presence: active instances → skip, no instances → safe to delete
- Add LB deletion polling + skip ELB-managed ENIs to prevent async race
  conditions during cleanup

## Problem
The cleanup script discovered VPCs exclusively via NAT gateways tagged
`origin=mapt`. Kind clusters never create NAT gateways, making them
invisible to the script. This caused ~287 orphaned VPCs to accumulate
(117 in us-west-2, 143 in us-east-1, 27 in us-east-2) along with
associated IGWs, subnets, security groups, route tables, and load balancers.

## Test plan
- [x] Dry-run against us-west-2 — verified only orphaned VPCs targeted
- [x] Real run against us-west-2 — 117 VPCs cleaned, zero errors
- [x] Dry-run against us-east-1 — 136 orphaned VPCs correctly identified
- [x] Verified active clusters (with running instances) are skipped
- [x] Verified LB async deletion race condition is fixed

## CI test
- tested with https://github.com/openshift/release/pull/80473