### PR TITLE
fix(CLOUDDST-30777): log improvements for deploy-fbc-operator

### DIFF
--- a/pipelines/deploy-fbc-operator/0.1/README.MD
+++ b/pipelines/deploy-fbc-operator/0.1/README.MD
@@ -4,25 +4,32 @@ The deploy-fbc-operator pipeline automates the provisioning of a EaaS Hypershift
 ## Pipeline Flow
 The pipeline consists of the following tasks:
 
-1. **Parse Metadata (`parse-metadata`)**  
+1. **Validate Parameters (`validate-parameters`)**
+   Validates whether all required parameters are properly passed to the pipeline.
+
+2. **Parse Metadata (`parse-metadata`)**  
    Extracts metadata from the provided *snapshot*, including:
      * FBC fragment container image
      * Source Git URL
      * Git revision
 
-2. **Provision EAAS Space (`provision-eaas-space`)**  
+3. **Log Non Push Tasks `log-non-push-tasks`**
+   Informs which tasks are going to be skipped for non `push` events, such as
+   `pull_request` or `retest-all-comment`
+
+4. **Provision EAAS Space (`provision-eaas-space`)**  
    Allocates an **Environment-as-a-Service (EaaS) space** for cluster provisioning.
 
-3. **Fetch Config Files (`fetch-config-files`)**
+5. **Fetch Config Files (`fetch-config-files`)**
    - Retrieves the authorization token if the source Git repository is private.
    - Downloads `.tekton/images-mirror-set.yaml` and `bundle/tests/scorecard/config.yaml` from the source Git repository.
    - Stores the raw YAML and the serialized versions of the ImageDigestMirrorSet and scorecard config images as Tekton results for use by downstream tasks.
 
-4. **Get Unreleased Bundle (`get-unreleased-bundle`)**
+6. **Get Unreleased Bundle (`get-unreleased-bundle`)**
    - Retrieves the **unreleased bundle** from the FBC fragment.
    - Processes **.tekton/images-mirror-set.yaml** to resolve mirrored image references, if available.
 
-5. **Pick Cluster Params (`pick-cluster-params`)**
+7. **Pick Cluster Params (`pick-cluster-params`)**
    - Fetches a list of supported **OpenShift versions** for Hypershift.
       
       The version of Multi-Cluster Engine (MCE) that is deployed for Hypershift dictates what cluster versions can be provisioned. For example, MCE 2.7 supports provisioning OCP 4.14–4.17.
@@ -33,11 +40,11 @@ The pipeline consists of the following tasks:
    - Selects the **target OpenShift version** for deployment.
    - Identifies the **supported cluster architecture** (`arm64`, `amd64`).
 
-6. **Provision Cluster (`provision-cluster`)**
+8. **Provision Cluster (`provision-cluster`)**
    - Retrieves the latest OpenShift **version tag**.
    - Provisions a **Hypershift AWS cluster** using the parameters selected above, along with the `imageContentSources` parameter, which contains the serialized image mirror set YAML used to apply IDMS to the running cluster.
 
-7. **Deploy Operator (`deploy-operator`)**  
+9. **Deploy Operator (`deploy-operator`)**  
    - Retrieves **Kubeconfig credentials** for cluster access.
    - Installs the **operator** on the newly provisioned cluster.
    - Gathers **cluster artifacts** for analysis and validation.
@@ -45,7 +52,7 @@ The pipeline consists of the following tasks:
    - Pushes gathered artifacts to an **OCI artifact repository** (e.g. Quay).
    - Fails the pipeline if operator installation fails.
 
-8. **Verify Image Sources (`verify-image-sources`)**  
+10. **Verify Image Sources (`verify-image-sources`)**  
    - Validates that each pulled image comes from an approved registry:
       * `registry.redhat.io`
       * `registry.access.redhat.com`

--- a/pipelines/deploy-fbc-operator/0.1/README.MD
+++ b/pipelines/deploy-fbc-operator/0.1/README.MD
@@ -5,6 +5,7 @@ The deploy-fbc-operator pipeline automates the provisioning of a EaaS Hypershift
 The pipeline consists of the following tasks:
 
 1. **Validate Parameters (`validate-parameters`)**
+
    Validates whether all required parameters are properly passed to the pipeline.
 
 2. **Parse Metadata (`parse-metadata`)**  
@@ -13,7 +14,7 @@ The pipeline consists of the following tasks:
      * Source Git URL
      * Git revision
 
-3. **Log Non Push Tasks `log-non-push-tasks`**
+3. **Log Non Push Tasks (`log-non-push-tasks`)**
    Informs which tasks are going to be skipped for non `push` events, such as
    `pull_request` or `retest-all-comment`
 

--- a/pipelines/deploy-fbc-operator/0.1/deploy-fbc-operator.yaml
+++ b/pipelines/deploy-fbc-operator/0.1/deploy-fbc-operator.yaml
@@ -136,9 +136,24 @@ spec:
               if [[ -z "${params.SLACK_KEY_NAME}" ]]; then
                 echo "WARNING: SLACK_KEY_NAME parameter is not set, sending notifications to Slack may not work."
               fi
-    - name: log-non-push-tasks
+    - name: parse-metadata
       runAfter:
         - validate-parameters
+      taskRef:
+        resolver: git
+        params:
+          - name: url
+            value: https://github.com/konflux-ci/integration-examples
+          - name: revision
+            value: main
+          - name: pathInRepo
+            value: tasks/test_metadata.yaml
+      params:
+        - name: SNAPSHOT
+          value: $(params.SNAPSHOT)
+    - name: log-non-push-tasks
+      runAfter:
+        - parse-metadata
       when:
         - input: $(tasks.parse-metadata.results.test-event-type)
           operator: notin
@@ -166,24 +181,9 @@ spec:
                 echo "- $task"
               done
               echo
-    - name: parse-metadata
-      runAfter:
-        - log-non-push-tasks
-      taskRef:
-        resolver: git
-        params:
-          - name: url
-            value: https://github.com/konflux-ci/integration-examples
-          - name: revision
-            value: main
-          - name: pathInRepo
-            value: tasks/test_metadata.yaml
-      params:
-        - name: SNAPSHOT
-          value: $(params.SNAPSHOT)
     - name: provision-eaas-space
       runAfter:
-        - parse-metadata
+        - log-non-push-tasks
       when:
         - input: $(tasks.parse-metadata.results.test-event-type)
           operator: in

--- a/pipelines/deploy-fbc-operator/0.1/deploy-fbc-operator.yaml
+++ b/pipelines/deploy-fbc-operator/0.1/deploy-fbc-operator.yaml
@@ -98,15 +98,9 @@ spec:
               #!/usr/bin/env bash
               set -euo pipefail
 
-              if [[ -z "${params.SNAPSHOT}" ]]; then
-                echo "SNAPSHOT parameter is required"
-                exit 1
-              fi
-
               if [[ -z "${params.PACKAGE_NAME}" ]]; then
                 echo "PACKAGE_NAME parameter is empty: the step will discover the package name in the FBC fragment."
               fi
-
 
               if [[ -z "${params.CHANNEL_NAME}" ]]; then
                 echo "CHANNEL_NAME parameter is empty. The step will determine the default channel name of the selected package."
@@ -131,10 +125,6 @@ spec:
 
               if [[ -z "${params.SLACK_SECRET_NAME}" ]]; then
                 echo "WARNING: SLACK_SECRET_NAME parameter is not set, sending notifications to Slack may not work."
-              fi
-
-              if [[ -z "${params.SLACK_KEY_NAME}" ]]; then
-                echo "WARNING: SLACK_KEY_NAME parameter is not set, sending notifications to Slack may not work."
               fi
     - name: parse-metadata
       runAfter:
@@ -183,7 +173,7 @@ spec:
               echo
     - name: provision-eaas-space
       runAfter:
-        - log-non-push-tasks
+        - parse-metadata
       when:
         - input: $(tasks.parse-metadata.results.test-event-type)
           operator: in

--- a/pipelines/deploy-fbc-operator/0.1/deploy-fbc-operator.yaml
+++ b/pipelines/deploy-fbc-operator/0.1/deploy-fbc-operator.yaml
@@ -139,9 +139,39 @@ spec:
               if [[ -z "${params.SLACK_KEY_NAME}" ]]; then
                 echo "WARNING: SLACK_KEY_NAME parameter is not set, sending notifications to Slack may not work."
               fi
-    - name: parse-metadata
+    - name: log-non-push-tasks
       runAfter:
         - validate-parameters
+      when:
+        - input: $(tasks.parse-metadata.results.test-event-type)
+          operator: notin
+          values: ["push", "Push"]
+      taskSpec:
+        steps:
+          - name: log-skipped-tasks
+            image: quay.io/konflux-ci/konflux-test:v1.4.48@sha256:9b815268fb2bf10b5d745518da1c6568944f15816efe51adc192972b42a6e74d
+            script: |
+              #!/usr/bin/env bash
+              set -euo pipefail
+
+              skipped_tasks=(
+                "provision-eaas-space"
+                "fetch-config-files"
+                "get-unreleased-bundle"
+                "pick-cluster-params"
+                "provision-cluster"
+                "deploy-operator"
+                "verify-image-sources"
+              )
+
+              echo "The following tasks are not going to be executed for the event type \"$(tasks.parse-metadata.results.test-event-type)\":"
+              for task in "${skipped_tasks[@]}"; do
+                echo "- $task"
+              done
+              echo
+    - name: parse-metadata
+      runAfter:
+        - log-non-push-tasks
       taskRef:
         resolver: git
         params:

--- a/pipelines/deploy-fbc-operator/0.1/deploy-fbc-operator.yaml
+++ b/pipelines/deploy-fbc-operator/0.1/deploy-fbc-operator.yaml
@@ -93,7 +93,7 @@ spec:
       taskSpec:
         steps:
           - name: validate-parameters
-            image: quay.io/konflux-ci/konflux-test:v1.4.48@sha256:9b815268fb2bf10b5d745518da1c6568944f15816efe51adc192972b42a6e74d
+            image: quay.io/konflux-ci/konflux-test:1.5.2@sha256:c370a7bc6e172cdbab001f1a19f37ebc95f47c3d8fe2d915fa4641132490ead7
             script: |
               #!/usr/bin/env bash
               set -euo pipefail
@@ -149,7 +149,7 @@ spec:
       taskSpec:
         steps:
           - name: log-skipped-tasks
-            image: quay.io/konflux-ci/konflux-test:v1.4.48@sha256:9b815268fb2bf10b5d745518da1c6568944f15816efe51adc192972b42a6e74d
+            image: quay.io/konflux-ci/konflux-test:1.5.2@sha256:c370a7bc6e172cdbab001f1a19f37ebc95f47c3d8fe2d915fa4641132490ead7
             script: |
               #!/usr/bin/env bash
               set -euo pipefail
@@ -222,7 +222,7 @@ spec:
             description: "Images pulled from the scorecard config YAML."
         steps:
           - name: retrieve-auth-header
-            image: quay.io/konflux-ci/konflux-test:v1.4.31@sha256:a7cae9e96663e277a3904d0c78630508ddb6cc8eebaa912a840bd20f68dcaad1
+            image: quay.io/konflux-ci/konflux-test:1.5.2@sha256:c370a7bc6e172cdbab001f1a19f37ebc95f47c3d8fe2d915fa4641132490ead7
             env:
               - name: SOURCE_GIT_URL
                 value: "$(tasks.parse-metadata.results.source-git-url)"
@@ -261,7 +261,7 @@ spec:
 
               echo "$AUTH_HEADER" > /tmp/auth_header.txt
           - name: retrieve-mirror-set-and-scorecard-config
-            image: quay.io/konflux-ci/konflux-test:v1.4.31@sha256:a7cae9e96663e277a3904d0c78630508ddb6cc8eebaa912a840bd20f68dcaad1
+            image: quay.io/konflux-ci/konflux-test:1.5.2@sha256:c370a7bc6e172cdbab001f1a19f37ebc95f47c3d8fe2d915fa4641132490ead7
             computeResources:
               limits:
                 memory: 512Mi
@@ -367,7 +367,7 @@ spec:
               - name: channelName
                 value: $(params.CHANNEL_NAME)
           - name: process-image-mirror-set
-            image: quay.io/konflux-ci/konflux-test:v1.4.31@sha256:a7cae9e96663e277a3904d0c78630508ddb6cc8eebaa912a840bd20f68dcaad1
+            image: quay.io/konflux-ci/konflux-test:1.5.2@sha256:c370a7bc6e172cdbab001f1a19f37ebc95f47c3d8fe2d915fa4641132490ead7
             computeResources:
               limits:
                 memory: 512Mi
@@ -629,7 +629,7 @@ spec:
             # In case the test fails, we don't want to fail the TaskRun immediately,
             # because we want to proceed with archiving the artifacts in a following step.
             onError: continue
-            image: quay.io/konflux-ci/konflux-test:v1.4.31@sha256:a7cae9e96663e277a3904d0c78630508ddb6cc8eebaa912a840bd20f68dcaad1
+            image: quay.io/konflux-ci/konflux-test:1.5.2@sha256:c370a7bc6e172cdbab001f1a19f37ebc95f47c3d8fe2d915fa4641132490ead7
             computeResources:
               limits:
                 memory: 4Gi
@@ -967,7 +967,7 @@ spec:
                 value: "/workspace/konflux-artifacts"
           # validate that the cluster resources are available in another tekton step
           - name: list-artifacts
-            image: quay.io/konflux-ci/konflux-test:v1.4.31@sha256:a7cae9e96663e277a3904d0c78630508ddb6cc8eebaa912a840bd20f68dcaad1
+            image: quay.io/konflux-ci/konflux-test:1.5.2@sha256:c370a7bc6e172cdbab001f1a19f37ebc95f47c3d8fe2d915fa4641132490ead7
             workingDir: "/workspace"
             script: |
               #!/bin/bash

--- a/pipelines/deploy-fbc-operator/0.1/deploy-fbc-operator.yaml
+++ b/pipelines/deploy-fbc-operator/0.1/deploy-fbc-operator.yaml
@@ -89,7 +89,59 @@ spec:
       default: "https://konflux-ui.apps.stone-prd-rh01.pg1f.p1.openshiftapps.com"
       type: string
   tasks:
+    - name: validate-parameters
+      taskSpec:
+        steps:
+          - name: validate-parameters
+            image: quay.io/konflux-ci/konflux-test:v1.4.48@sha256:9b815268fb2bf10b5d745518da1c6568944f15816efe51adc192972b42a6e74d
+            script: |
+              #!/usr/bin/env bash
+              set -euo pipefail
+
+              if [[ -z "${params.SNAPSHOT}" ]]; then
+                echo "SNAPSHOT parameter is required"
+                exit 1
+              fi
+
+              if [[ -z "${params.PACKAGE_NAME}" ]]; then
+                echo "WARNING: PACKAGE_NAME parameter is not set, using empty package name"
+              fi
+
+              if [[ -z "${params.CHANNEL_NAME}" ]]; then
+<<<<<<< Updated upstream
+                echo "WARNING: CHANNEL_NAME parameter is not set, using empty channel name"
+=======
+                echo "CHANNEL_NAME parameter is empty. The step will determine the default channel name of the selected package."
+>>>>>>> Stashed changes
+              fi
+
+              if [[ -z "${params.CREDENTIALS_SECRET_NAME}" ]]; then
+                echo "CREDENTIALS_SECRET_NAME parameter is required"
+                exit 1
+              fi
+
+              if [[ -z "${params.OCI_REF}" ]]; then
+                echo "OCI_REF parameter is required"
+                exit 1
+              fi
+
+              if [[ -z "${params.REPO_TOKEN}" &&  -z "${params.REPO_KEY}" ]]; then
+                echo "WARNING: REPO_TOKEN and REPO_KEY parameters are not set."
+              elif [[ -z "${params.REPO_TOKEN}" || -z "${params.REPO_KEY}" ]]; then
+                echo "REPO_TOKEN and REPO_KEY should be set together."
+                exit 1
+              fi
+
+              if [[ -z "${params.SLACK_SECRET_NAME}" ]]; then
+                echo "WARNING: SLACK_SECRET_NAME parameter is not set, sending notifications to Slack may not work."
+              fi
+
+              if [[ -z "${params.SLACK_KEY_NAME}" ]]; then
+                echo "WARNING: SLACK_KEY_NAME parameter is not set, sending notifications to Slack may not work."
+              fi
     - name: parse-metadata
+      runAfter:
+        - validate-parameters
       taskRef:
         resolver: git
         params:

--- a/pipelines/deploy-fbc-operator/0.1/deploy-fbc-operator.yaml
+++ b/pipelines/deploy-fbc-operator/0.1/deploy-fbc-operator.yaml
@@ -104,15 +104,12 @@ spec:
               fi
 
               if [[ -z "${params.PACKAGE_NAME}" ]]; then
-                echo "WARNING: PACKAGE_NAME parameter is not set, using empty package name"
+                echo "PACKAGE_NAME parameter is empty: the step will discover the package name in the FBC fragment."
               fi
 
+
               if [[ -z "${params.CHANNEL_NAME}" ]]; then
-<<<<<<< Updated upstream
-                echo "WARNING: CHANNEL_NAME parameter is not set, using empty channel name"
-=======
                 echo "CHANNEL_NAME parameter is empty. The step will determine the default channel name of the selected package."
->>>>>>> Stashed changes
               fi
 
               if [[ -z "${params.CREDENTIALS_SECRET_NAME}" ]]; then

--- a/pipelines/deploy-fbc-operator/0.1/deploy-fbc-operator.yaml
+++ b/pipelines/deploy-fbc-operator/0.1/deploy-fbc-operator.yaml
@@ -98,32 +98,32 @@ spec:
               #!/usr/bin/env bash
               set -euo pipefail
 
-              if [[ -z "${params.PACKAGE_NAME}" ]]; then
+              if [[ -z "$(params.PACKAGE_NAME)" ]]; then
                 echo "PACKAGE_NAME parameter is empty: the step will discover the package name in the FBC fragment."
               fi
 
-              if [[ -z "${params.CHANNEL_NAME}" ]]; then
+              if [[ -z "$(params.CHANNEL_NAME)" ]]; then
                 echo "CHANNEL_NAME parameter is empty. The step will determine the default channel name of the selected package."
               fi
 
-              if [[ -z "${params.CREDENTIALS_SECRET_NAME}" ]]; then
+              if [[ -z "$(params.CREDENTIALS_SECRET_NAME)" ]]; then
                 echo "CREDENTIALS_SECRET_NAME parameter is required"
                 exit 1
               fi
 
-              if [[ -z "${params.OCI_REF}" ]]; then
+              if [[ -z "$(params.OCI_REF)" ]]; then
                 echo "OCI_REF parameter is required"
                 exit 1
               fi
 
-              if [[ -z "${params.REPO_TOKEN}" &&  -z "${params.REPO_KEY}" ]]; then
+              if [[ -z "$(params.REPO_TOKEN)" &&  -z "$(params.REPO_KEY)" ]]; then
                 echo "WARNING: REPO_TOKEN and REPO_KEY parameters are not set."
-              elif [[ -z "${params.REPO_TOKEN}" || -z "${params.REPO_KEY}" ]]; then
+              elif [[ -z "$(params.REPO_TOKEN)" || -z "$(params.REPO_KEY)" ]]; then
                 echo "REPO_TOKEN and REPO_KEY should be set together."
                 exit 1
               fi
 
-              if [[ -z "${params.SLACK_SECRET_NAME}" ]]; then
+              if [[ -z "$(params.SLACK_SECRET_NAME)" ]]; then
                 echo "WARNING: SLACK_SECRET_NAME parameter is not set, sending notifications to Slack may not work."
               fi
     - name: parse-metadata

--- a/pipelines/deploy-fbc-operator/0.2/README.MD
+++ b/pipelines/deploy-fbc-operator/0.2/README.MD
@@ -20,25 +20,32 @@ A new version of the pipeline (`0.2`) has been introduced to improve handling of
 ## Pipeline Flow
 The pipeline consists of the following tasks:
 
-1. **Parse Metadata (`parse-metadata`)**  
+1. **Validate Parameters (`validate-parameters`)**
+   Validates whether all required parameters are properly passed to the pipeline.
+
+2. **Parse Metadata (`parse-metadata`)**  
    Extracts metadata from the provided *snapshot*, including:
      * FBC fragment container image
      * Source Git URL
      * Git revision
 
-2. **Provision EAAS Space (`provision-eaas-space`)**  
+3. **Log Non Push Tasks `log-non-push-tasks`**
+   Informs which tasks are going to be skipped for non `push` events, such as
+   `pull_request` or `retest-all-comment`
+
+4. **Provision EAAS Space (`provision-eaas-space`)**  
    Allocates an **Environment-as-a-Service (EaaS) space** for cluster provisioning.
 
-3. **Fetch Config Files (`fetch-config-files`)**
+5. **Fetch Config Files (`fetch-config-files`)**
    - Retrieves the authorization token if the source Git repository is private.
    - Downloads `.tekton/images-mirror-set.yaml` and `bundle/tests/scorecard/config.yaml` from the source Git repository.
    - Stores the raw YAML and serialized forms of the ImageDigestMirrorSet in a shared workspace for use by downstream tasks, and records the scorecard configuration images as a task result.
 
-4. **Get Unreleased Bundle (`get-unreleased-bundle`)**
+6. **Get Unreleased Bundle (`get-unreleased-bundle`)**
    - Retrieves the **unreleased bundle** from the FBC fragment.
    - Processes **.tekton/images-mirror-set.yaml** to resolve mirrored image references, if available.
 
-5. **Pick Cluster Params (`pick-cluster-params`)**
+7. **Pick Cluster Params (`pick-cluster-params`)**
    - Fetches a list of supported **OpenShift versions** for Hypershift.
       
       The version of Multi-Cluster Engine (MCE) that is deployed for Hypershift dictates what cluster versions can be provisioned. For example, MCE 2.7 supports provisioning OCP 4.14–4.17.
@@ -49,11 +56,11 @@ The pipeline consists of the following tasks:
    - Selects the **target OpenShift version** for deployment.
    - Identifies the **supported cluster architecture** (`arm64`, `amd64`).
 
-6. **Provision Cluster (`provision-cluster`)**
+8. **Provision Cluster (`provision-cluster`)**
    - Retrieves the latest OpenShift **version tag**.
    - Provisions a **Hypershift AWS cluster** using the parameters selected above, along with the `imageContentSources` parameter, which points to the serialized image mirror set stored in a shared workspace. This file is then applied to the running cluster to configure the ImageDigestMirrorSet (IDMS).
 
-7. **Deploy Operator (`deploy-operator`)**  
+9. **Deploy Operator (`deploy-operator`)**  
    - Retrieves **Kubeconfig credentials** for cluster access.
    - Installs the **operator** on the newly provisioned cluster.
    - Gathers **cluster artifacts** for analysis and validation.
@@ -61,7 +68,7 @@ The pipeline consists of the following tasks:
    - Pushes gathered artifacts to an **OCI artifact repository** (e.g. Quay).
    - Fails the pipeline if operator installation fails.
 
-8. **Verify Image Sources (`verify-image-sources`)**  
+10. **Verify Image Sources (`verify-image-sources`)**  
    - Validates that each pulled image comes from an approved registry:
       * `registry.redhat.io`
       * `registry.access.redhat.com`

--- a/pipelines/deploy-fbc-operator/0.2/README.MD
+++ b/pipelines/deploy-fbc-operator/0.2/README.MD
@@ -21,6 +21,7 @@ A new version of the pipeline (`0.2`) has been introduced to improve handling of
 The pipeline consists of the following tasks:
 
 1. **Validate Parameters (`validate-parameters`)**
+
    Validates whether all required parameters are properly passed to the pipeline.
 
 2. **Parse Metadata (`parse-metadata`)**  

--- a/pipelines/deploy-fbc-operator/0.2/deploy-fbc-operator.yaml
+++ b/pipelines/deploy-fbc-operator/0.2/deploy-fbc-operator.yaml
@@ -100,15 +100,9 @@ spec:
               #!/usr/bin/env bash
               set -euo pipefail
 
-              if [[ -z "${params.SNAPSHOT}" ]]; then
-                echo "SNAPSHOT parameter is required"
-                exit 1
-              fi
-
               if [[ -z "${params.PACKAGE_NAME}" ]]; then
                 echo "PACKAGE_NAME parameter is empty: the step will discover the package name in the FBC fragment."
               fi
-
 
               if [[ -z "${params.CHANNEL_NAME}" ]]; then
                 echo "CHANNEL_NAME parameter is empty. The step will determine the default channel name of the selected package."
@@ -133,10 +127,6 @@ spec:
 
               if [[ -z "${params.SLACK_SECRET_NAME}" ]]; then
                 echo "WARNING: SLACK_SECRET_NAME parameter is not set, sending notifications to Slack may not work."
-              fi
-
-              if [[ -z "${params.SLACK_KEY_NAME}" ]]; then
-                echo "WARNING: SLACK_KEY_NAME parameter is not set, sending notifications to Slack may not work."
               fi
     - name: parse-metadata
       runAfter:
@@ -185,7 +175,7 @@ spec:
               echo
     - name: provision-eaas-space
       runAfter:
-        - log-non-push-tasks
+        - parse-metadata
       when:
         - input: $(tasks.parse-metadata.results.test-event-type)
           operator: in

--- a/pipelines/deploy-fbc-operator/0.2/deploy-fbc-operator.yaml
+++ b/pipelines/deploy-fbc-operator/0.2/deploy-fbc-operator.yaml
@@ -141,9 +141,39 @@ spec:
               if [[ -z "${params.SLACK_KEY_NAME}" ]]; then
                 echo "WARNING: SLACK_KEY_NAME parameter is not set, sending notifications to Slack may not work."
               fi
+    - name: log-non-push-tasks
+      runAfter:
+        - validate-parameters
+      when:
+        - input: $(tasks.parse-metadata.results.test-event-type)
+          operator: notin
+          values: ["push", "Push"]
+      taskSpec:
+        steps:
+          - name: log-skipped-tasks
+            image: quay.io/konflux-ci/konflux-test:v1.4.48@sha256:9b815268fb2bf10b5d745518da1c6568944f15816efe51adc192972b42a6e74d
+            script: |
+              #!/usr/bin/env bash
+              set -euo pipefail
+
+              skipped_tasks=(
+                "provision-eaas-space"
+                "fetch-config-files"
+                "get-unreleased-bundle"
+                "pick-cluster-params"
+                "provision-cluster"
+                "deploy-operator"
+                "verify-image-sources"
+              )
+
+              echo "The following tasks are not going to be executed for the event type \"$(tasks.parse-metadata.results.test-event-type)\":"
+              for task in "${skipped_tasks[@]}"; do
+                echo "- $task"
+              done
+              echo
     - name: parse-metadata
       runAfter:
-          - validate-parameters
+        - log-non-push-tasks
       taskRef:
         resolver: git
         params:

--- a/pipelines/deploy-fbc-operator/0.2/deploy-fbc-operator.yaml
+++ b/pipelines/deploy-fbc-operator/0.2/deploy-fbc-operator.yaml
@@ -106,15 +106,12 @@ spec:
               fi
 
               if [[ -z "${params.PACKAGE_NAME}" ]]; then
-                echo "WARNING: PACKAGE_NAME parameter is not set, using empty package name"
+                echo "PACKAGE_NAME parameter is empty: the step will discover the package name in the FBC fragment."
               fi
 
+
               if [[ -z "${params.CHANNEL_NAME}" ]]; then
-<<<<<<< Updated upstream
-                echo "WARNING: CHANNEL_NAME parameter is not set, using empty channel name"
-=======
                 echo "CHANNEL_NAME parameter is empty. The step will determine the default channel name of the selected package."
->>>>>>> Stashed changes
               fi
 
               if [[ -z "${params.CREDENTIALS_SECRET_NAME}" ]]; then

--- a/pipelines/deploy-fbc-operator/0.2/deploy-fbc-operator.yaml
+++ b/pipelines/deploy-fbc-operator/0.2/deploy-fbc-operator.yaml
@@ -138,9 +138,24 @@ spec:
               if [[ -z "${params.SLACK_KEY_NAME}" ]]; then
                 echo "WARNING: SLACK_KEY_NAME parameter is not set, sending notifications to Slack may not work."
               fi
-    - name: log-non-push-tasks
+    - name: parse-metadata
       runAfter:
         - validate-parameters
+      taskRef:
+        resolver: git
+        params:
+          - name: url
+            value: https://github.com/konflux-ci/integration-examples
+          - name: revision
+            value: main
+          - name: pathInRepo
+            value: tasks/test_metadata.yaml
+      params:
+        - name: SNAPSHOT
+          value: $(params.SNAPSHOT)
+    - name: log-non-push-tasks
+      runAfter:
+        - parse-metadata
       when:
         - input: $(tasks.parse-metadata.results.test-event-type)
           operator: notin
@@ -168,24 +183,9 @@ spec:
                 echo "- $task"
               done
               echo
-    - name: parse-metadata
-      runAfter:
-        - log-non-push-tasks
-      taskRef:
-        resolver: git
-        params:
-          - name: url
-            value: https://github.com/konflux-ci/integration-examples
-          - name: revision
-            value: main
-          - name: pathInRepo
-            value: tasks/test_metadata.yaml
-      params:
-        - name: SNAPSHOT
-          value: $(params.SNAPSHOT)
     - name: provision-eaas-space
       runAfter:
-        - parse-metadata
+        - log-non-push-tasks
       when:
         - input: $(tasks.parse-metadata.results.test-event-type)
           operator: in

--- a/pipelines/deploy-fbc-operator/0.2/deploy-fbc-operator.yaml
+++ b/pipelines/deploy-fbc-operator/0.2/deploy-fbc-operator.yaml
@@ -95,7 +95,7 @@ spec:
       taskSpec:
         steps:
           - name: validate-parameters
-            image: quay.io/konflux-ci/konflux-test:v1.4.48@sha256:9b815268fb2bf10b5d745518da1c6568944f15816efe51adc192972b42a6e74d
+            image: quay.io/konflux-ci/konflux-test:1.5.2@sha256:c370a7bc6e172cdbab001f1a19f37ebc95f47c3d8fe2d915fa4641132490ead7
             script: |
               #!/usr/bin/env bash
               set -euo pipefail
@@ -151,7 +151,7 @@ spec:
       taskSpec:
         steps:
           - name: log-skipped-tasks
-            image: quay.io/konflux-ci/konflux-test:v1.4.48@sha256:9b815268fb2bf10b5d745518da1c6568944f15816efe51adc192972b42a6e74d
+            image: quay.io/konflux-ci/konflux-test:1.5.2@sha256:c370a7bc6e172cdbab001f1a19f37ebc95f47c3d8fe2d915fa4641132490ead7
             script: |
               #!/usr/bin/env bash
               set -euo pipefail
@@ -225,7 +225,7 @@ spec:
             description: "Images pulled from the scorecard config YAML."
         steps:
           - name: retrieve-auth-header
-            image: quay.io/konflux-ci/konflux-test:v1.4.48@sha256:9b815268fb2bf10b5d745518da1c6568944f15816efe51adc192972b42a6e74d
+            image: quay.io/konflux-ci/konflux-test:1.5.2@sha256:c370a7bc6e172cdbab001f1a19f37ebc95f47c3d8fe2d915fa4641132490ead7
             env:
               - name: SOURCE_GIT_URL
                 value: "$(tasks.parse-metadata.results.source-git-url)"
@@ -264,7 +264,7 @@ spec:
 
               echo "$AUTH_HEADER" > /tmp/auth_header.txt
           - name: retrieve-mirror-set-and-scorecard-config
-            image: quay.io/konflux-ci/konflux-test:v1.4.48@sha256:9b815268fb2bf10b5d745518da1c6568944f15816efe51adc192972b42a6e74d
+            image: quay.io/konflux-ci/konflux-test:1.5.2@sha256:c370a7bc6e172cdbab001f1a19f37ebc95f47c3d8fe2d915fa4641132490ead7
             computeResources:
               limits:
                 memory: 512Mi
@@ -375,7 +375,7 @@ spec:
               - name: channelName
                 value: $(params.CHANNEL_NAME)
           - name: process-image-mirror-set
-            image: quay.io/konflux-ci/konflux-test:v1.4.48@sha256:9b815268fb2bf10b5d745518da1c6568944f15816efe51adc192972b42a6e74d
+            image: quay.io/konflux-ci/konflux-test:1.5.2@sha256:c370a7bc6e172cdbab001f1a19f37ebc95f47c3d8fe2d915fa4641132490ead7
             computeResources:
               limits:
                 memory: 512Mi
@@ -641,7 +641,7 @@ spec:
             # In case the test fails, we don't want to fail the TaskRun immediately,
             # because we want to proceed with archiving the artifacts in a following step.
             onError: continue
-            image: quay.io/konflux-ci/konflux-test:v1.4.48@sha256:9b815268fb2bf10b5d745518da1c6568944f15816efe51adc192972b42a6e74d
+            image: quay.io/konflux-ci/konflux-test:1.5.2@sha256:c370a7bc6e172cdbab001f1a19f37ebc95f47c3d8fe2d915fa4641132490ead7
             computeResources:
               limits:
                 memory: 4Gi
@@ -970,7 +970,7 @@ spec:
                 value: "/workspace/konflux-artifacts"
           # validate that the cluster resources are available in another tekton step
           - name: list-artifacts
-            image: quay.io/konflux-ci/konflux-test:v1.4.48@sha256:9b815268fb2bf10b5d745518da1c6568944f15816efe51adc192972b42a6e74d
+            image: quay.io/konflux-ci/konflux-test:1.5.2@sha256:c370a7bc6e172cdbab001f1a19f37ebc95f47c3d8fe2d915fa4641132490ead7
             workingDir: "/workspace"
             script: |
               #!/bin/bash

--- a/pipelines/deploy-fbc-operator/0.2/deploy-fbc-operator.yaml
+++ b/pipelines/deploy-fbc-operator/0.2/deploy-fbc-operator.yaml
@@ -91,7 +91,59 @@ spec:
   workspaces:
     - name: shared-data
   tasks:
+    - name: validate-parameters
+      taskSpec:
+        steps:
+          - name: validate-parameters
+            image: quay.io/konflux-ci/konflux-test:v1.4.48@sha256:9b815268fb2bf10b5d745518da1c6568944f15816efe51adc192972b42a6e74d
+            script: |
+              #!/usr/bin/env bash
+              set -euo pipefail
+
+              if [[ -z "${params.SNAPSHOT}" ]]; then
+                echo "SNAPSHOT parameter is required"
+                exit 1
+              fi
+
+              if [[ -z "${params.PACKAGE_NAME}" ]]; then
+                echo "WARNING: PACKAGE_NAME parameter is not set, using empty package name"
+              fi
+
+              if [[ -z "${params.CHANNEL_NAME}" ]]; then
+<<<<<<< Updated upstream
+                echo "WARNING: CHANNEL_NAME parameter is not set, using empty channel name"
+=======
+                echo "CHANNEL_NAME parameter is empty. The step will determine the default channel name of the selected package."
+>>>>>>> Stashed changes
+              fi
+
+              if [[ -z "${params.CREDENTIALS_SECRET_NAME}" ]]; then
+                echo "CREDENTIALS_SECRET_NAME parameter is required"
+                exit 1
+              fi
+
+              if [[ -z "${params.OCI_REF}" ]]; then
+                echo "OCI_REF parameter is required"
+                exit 1
+              fi
+
+              if [[ -z "${params.REPO_TOKEN}" &&  -z "${params.REPO_KEY}" ]]; then
+                echo "WARNING: REPO_TOKEN and REPO_KEY parameters are not set."
+              elif [[ -z "${params.REPO_TOKEN}" || -z "${params.REPO_KEY}" ]]; then
+                echo "REPO_TOKEN and REPO_KEY should be set together."
+                exit 1
+              fi
+
+              if [[ -z "${params.SLACK_SECRET_NAME}" ]]; then
+                echo "WARNING: SLACK_SECRET_NAME parameter is not set, sending notifications to Slack may not work."
+              fi
+
+              if [[ -z "${params.SLACK_KEY_NAME}" ]]; then
+                echo "WARNING: SLACK_KEY_NAME parameter is not set, sending notifications to Slack may not work."
+              fi
     - name: parse-metadata
+      runAfter:
+          - validate-parameters
       taskRef:
         resolver: git
         params:

--- a/pipelines/deploy-fbc-operator/0.2/deploy-fbc-operator.yaml
+++ b/pipelines/deploy-fbc-operator/0.2/deploy-fbc-operator.yaml
@@ -100,32 +100,32 @@ spec:
               #!/usr/bin/env bash
               set -euo pipefail
 
-              if [[ -z "${params.PACKAGE_NAME}" ]]; then
+              if [[ -z "$(params.PACKAGE_NAME)" ]]; then
                 echo "PACKAGE_NAME parameter is empty: the step will discover the package name in the FBC fragment."
               fi
 
-              if [[ -z "${params.CHANNEL_NAME}" ]]; then
+              if [[ -z "$(params.CHANNEL_NAME)" ]]; then
                 echo "CHANNEL_NAME parameter is empty. The step will determine the default channel name of the selected package."
               fi
 
-              if [[ -z "${params.CREDENTIALS_SECRET_NAME}" ]]; then
+              if [[ -z "$(params.CREDENTIALS_SECRET_NAME)" ]]; then
                 echo "CREDENTIALS_SECRET_NAME parameter is required"
                 exit 1
               fi
 
-              if [[ -z "${params.OCI_REF}" ]]; then
+              if [[ -z "$(params.OCI_REF)" ]]; then
                 echo "OCI_REF parameter is required"
                 exit 1
               fi
 
-              if [[ -z "${params.REPO_TOKEN}" &&  -z "${params.REPO_KEY}" ]]; then
+              if [[ -z "$(params.REPO_TOKEN)" &&  -z "$(params.REPO_KEY)" ]]; then
                 echo "WARNING: REPO_TOKEN and REPO_KEY parameters are not set."
-              elif [[ -z "${params.REPO_TOKEN}" || -z "${params.REPO_KEY}" ]]; then
+              elif [[ -z "$(params.REPO_TOKEN)" || -z "$(params.REPO_KEY)" ]]; then
                 echo "REPO_TOKEN and REPO_KEY should be set together."
                 exit 1
               fi
 
-              if [[ -z "${params.SLACK_SECRET_NAME}" ]]; then
+              if [[ -z "$(params.SLACK_SECRET_NAME)" ]]; then
                 echo "WARNING: SLACK_SECRET_NAME parameter is not set, sending notifications to Slack may not work."
               fi
     - name: parse-metadata


### PR DESCRIPTION
This PR contains the following changes:

## Validate parameters for deploy-fbc-operator
    
This commit introduces a new task named `validate-parameters` which will  be executed first in the pipeline.
    
This newly added task will raise errors when required secrets/parameters are not set as well as emit warnings for the ones which are missing so the end user can properly debug.
    
The goal of this change is to prevent a scenario which the pipeline gets stuck without any error messages due to missing secrets, as well as early failing/warning for missing fields.

## Log skipped tasks for deploy-fbc-operator
    
This commit enhances the logging for `deploy-fbc-operator` by informing which tasks are going to be skipped for non "push" events, such as  "pull_request" or "retest-all-comment".

## JIRA
Refers to CLOUDDST-30777