### PR TITLE
fix: skip commenting when pipelinerun status is completed as well

### DIFF
--- a/tasks/pull-request-comment/0.1/pull-request-comment.yaml
+++ b/tasks/pull-request-comment/0.1/pull-request-comment.yaml
@@ -109,7 +109,7 @@ spec:
         - name: konflux-test-infra-volume
           mountPath: /usr/local/konflux-test-infra
       script: |
-        #!/bin/sh
+        #!/bin/bash
 
         PIPELINE_STATUS=$(kubectl get pipelinerun $(params.test-name) -o jsonpath='{.status.conditions[0].reason}')
 

--- a/tasks/pull-request-comment/0.1/pull-request-comment.yaml
+++ b/tasks/pull-request-comment/0.1/pull-request-comment.yaml
@@ -162,7 +162,7 @@ spec:
         done
 
         # If the pipeline succeeded, do not post a new comment and exit
-        if [[ "$PIPELINE_RUN_AGGREGATE_STATUS" == "Succeeded" ]]; then
+        if [[ "$PIPELINE_RUN_AGGREGATE_STATUS" == "Succeeded" || "$PIPELINE_RUN_AGGREGATE_STATUS" == "Completed" ]]; then
             echo "[INFO]: Pipeline finished successfully. No new comment will be posted."
             exit 0
         fi

--- a/tasks/pull-request-comment/0.2/pull-request-comment.yaml
+++ b/tasks/pull-request-comment/0.2/pull-request-comment.yaml
@@ -151,7 +151,7 @@ spec:
         done
 
         # If the pipeline succeeded, do not post a new comment and exit
-        if [[ "$PIPELINE_RUN_AGGREGATE_STATUS" == "Succeeded" ]]; then
+        if [[ "$PIPELINE_RUN_AGGREGATE_STATUS" == "Succeeded" || "$PIPELINE_RUN_AGGREGATE_STATUS" == "Completed" ]]; then
             echo "[INFO]: Pipeline finished successfully. No new comment will be posted."
             exit 0
         fi

--- a/tasks/pull-request-comment/0.2/pull-request-comment.yaml
+++ b/tasks/pull-request-comment/0.2/pull-request-comment.yaml
@@ -99,7 +99,7 @@ spec:
         - name: konflux-test-infra-volume
           mountPath: /usr/local/konflux-test-infra
       script: |
-        #!/bin/sh
+        #!/bin/bash
 
         PIPELINE_STATUS=$(kubectl get pipelinerun $(params.test-name) -o jsonpath='{.status.conditions[0].reason}')
 


### PR DESCRIPTION
the pipeline run status is `Completed`  when some tasks are skipped in a pipelinerun, we don't want to comment in that scenario as well.
```
  conditions:
    - lastTransitionTime: '2026-06-16T09:39:38Z'
      message: 'Tasks Completed: 12 (Failed: 0, Cancelled 0), Skipped: 1'
      reason: Completed
      status: 'True'
      type: Succeeded
```